### PR TITLE
Tiny typo fix

### DIFF
--- a/examples/redis/redis.go
+++ b/examples/redis/redis.go
@@ -37,7 +37,7 @@ func main() {
         mc.Set("k1", "v1")
         mc.Get("k1")
     })
-    if mcrep.Err != nil {
+    if mcRep.Err != nil {
         panic(mcRep.Err)
     }
     mcVal, _ := mcRep.Elems[1].Str()


### PR DESCRIPTION
The redis example doesn't run at the moment before of a really small variable casing mistake.
