### PR TITLE
Updated build instructions to use tools/ instead of tool/

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Go by Example site is served by a
 To build the site:
 
 ```console
-$ tool/build
+$ tools/build
 $ open site/index.html
 ```
 
 To build continuously in a loop:
 
 ```console
-$ tool/build-loop
+$ tools/build-loop
 ```
 
 Builds require the [`pygmentize`](http://pygments.org/)


### PR DESCRIPTION
The build instructions seem to have a typo.  The console commands listed use tool/ instead of tools/.
