### PR TITLE
Minor typo in template directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Content and toolchain for [Go by Example](https://gobyexample.com).
 
 The Go by Example site is built by extracting code &
 comments from source files in `examples` and rendering
-that data via the site `templates`. The programs
+that data via the site `template`. The programs
 implementing this build process are in `tools`.
 
 The build process produces a directory of static files


### PR DESCRIPTION
Either the overview needed to be updated to 'template' from 'templates', or the directory needs to be renamed from template to templates.  This patch is the easier of the two, though renaming the directory would make it more consistently named with the other directories.
