### PR TITLE
Minor spelling fix: s/accross/across/

### DIFF
--- a/examples/select/select.go
+++ b/examples/select/select.go
@@ -9,7 +9,7 @@ import "fmt"
 
 func main() {
 
-    // For our example we'll select accross two channels.
+    // For our example we'll select across two channels.
     c1 := make(chan string)
     c2 := make(chan string)
 


### PR DESCRIPTION
Amazing stuff Mark. I feel like I'm finally learning Go ;)
