### PR TITLE
there's more to say about constants

### DIFF
--- a/examples/constants/constants.go
+++ b/examples/constants/constants.go
@@ -10,4 +10,20 @@ const s string = "constant"
 
 func main() {
     fmt.Println(s)
+
+    // A `const` statement can appear anywhere a `var` statement can.
+    const n = 500000000
+
+    // Constant expressions perform arithmetic with arbitrary precision.
+    const d = 3e20 / n
+
+    // A numeric constant has no type until it's given one, such as by
+    // an explicit cast.
+    fmt.Println(int64(d))
+
+    // A number can also be given a type by using it in a context that
+    // requires one, such as a variable assignment or funcion call.
+    // The type it gets depends on its value.
+    fmt.Println(n) // int
+    fmt.Println(d) // float64
 }


### PR DESCRIPTION
This was a small source of confusion for me when I was getting started.

Go constants have their own type system, distinct from the language's
primary type system, that exists only at compile time.

I took a stab at explaining just enough to un-confuse people. (Also,
these days the compiler error messages around constants are better,
so this is hopefully less of a problem.)
