### PR TITLE
Minor text fix

### DIFF
--- a/examples/atomic-counters/atomic-counters.go
+++ b/examples/atomic-counters/atomic-counters.go
@@ -46,6 +46,3 @@ func main() {
     opsFinal := atomic.LoadUint64(&ops)
     fmt.Println("ops:", opsFinal)
 }
-
-// Next we'll look at another approach to managing state:
-// mutexes.


### PR DESCRIPTION
The text announcing mutexes is already on atomic-counters.sh, it's showing twice.
