### PR TITLE
Use runtime.Gosched() instead of time.Sleep

### DIFF
--- a/examples/atomic-counters/atomic-counters.go
+++ b/examples/atomic-counters/atomic-counters.go
@@ -10,6 +10,7 @@ package main
 import "fmt"
 import "time"
 import "sync/atomic"
+import "runtime"
 
 func main() {
 
@@ -22,14 +23,14 @@ func main() {
     // once a millisecond.
     for i := 0; i < 50; i++ {
         go func() {
-            for {
-                time.Sleep(time.Millisecond)
-
+            for {            
                 // To atomically increment the counter we
                 // use `AddUint64`, giving it the memory
                 // address of our `ops` counter with the
                 // `&` syntax.
                 atomic.AddUint64(&ops, 1)
+                
+                runtime.Gosched()
             }
         }()
     }


### PR DESCRIPTION
Its not clear for newbies that using `time.Sleep` internally calls  `runtime.Gosched()`

Its better to use it directly, moreover on my machine it shows x175 improvement in speed (7m requests per second vs 40k).
