### PR TITLE
Move `state` variable internal to stateful goroutine.

### DIFF
--- a/examples/stateful-goroutines/stateful-goroutines.go
+++ b/examples/stateful-goroutines/stateful-goroutines.go
@@ -36,12 +36,7 @@ type writeOp struct {
 
 func main() {
 
-    // The `state` will be a map as in the previous
-    // example.
-    var state = make(map[int]int)
-
-    // Also as before we'll count how many operations we
-    // perform.
+    // As before we'll count how many operations we perform.
     var ops int64 = 0
 
     // The `reads` and `writes` channels will be used by
@@ -50,14 +45,18 @@ func main() {
     reads := make(chan *readOp)
     writes := make(chan *writeOp)
 
-    // Here is the goroutine that owns the `state`. This
-    // goroutine repeatedly selects on the `reads` and
+    // Here is the goroutine that owns the `state`, which 
+    // is a map as in the previous example, but is held 
+    // internally so all changes are handled by this function.
+    // This goroutine repeatedly selects on the `reads` and
     // `writes` channels, responding to requests as they
     // arrive. A response is executed by first performing
     // the requested operation and then sending a value
     // on the response channel `resp` to indicate success
     // (and the desired value in the case of `reads`).
     go func() {
+        var state = make(map[int]int)
+
         for {
             select {
             case read := <-reads:


### PR DESCRIPTION
This is more of a question about Go phrased as a pull request than a request for you to actually change this example. Pull this in if it makes sense, but I'd really just like to know if this is a better or worse way of doing things. 

In the `stateful-goroutines` example, the `state` is at the top-level of the `main` function and then a goroutine owns any changes this state via `readOp`s and `writeOp`s. Because the `state` is external to the goroutine, there is nothing stopping others from sidestepping the synchronization and manipulating it on their own. This change moves the `state` internal to the goroutine to control access. 

I'm just wondering if this was an oversight in the example or if there is a reason I'm missing to have the state outside the function.
