### PR TITLE
Tweak JSON example of unmarshalling a float

### DIFF
--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -69,7 +69,7 @@ func main() {
     // Now let's look at decoding JSON data into Go
     // values. Here's an example for a generic data
     // structure.
-    byt := []byte(`{"num":6.0,"strs":["a","b"]}`)
+    byt := []byte(`{"num":6.13,"strs":["a","b"]}`)
 
     // We need to provide a variable where the JSON
     // package can put the decoded data. This

--- a/examples/json/json.hash
+++ b/examples/json/json.hash
@@ -1,2 +1,2 @@
-12f985bb444e2bd6d72ea52a24ebc5f4f82c5b9b
-4L2wMVv7tW
+9a3d67892b3930bceb1167b59d4d4f5527dadefc
+scgxBwACYx

--- a/examples/json/json.sh
+++ b/examples/json/json.sh
@@ -7,8 +7,8 @@ true
 {"apple":5,"lettuce":7}
 {"Page":1,"Fruits":["apple","peach","pear"]}
 {"page":1,"fruits":["apple","peach","pear"]}
-map[num:6 strs:[a b]]
-6
+map[num:6.13 strs:[a b]]
+6.13
 a
 &{1 [apple peach]}
 apple

--- a/public/hello-world
+++ b/public/hello-world
@@ -25,7 +25,7 @@
         
         <tr>
           <td class="docs">
-            <p>Our first program will print the classic &ldquo;hello world&rdquo;
+            <p>Our first program will print the classic &ldquo;hello world&rdquo;`
 message. Here&rsquo;s the full source code.</p>
 
           </td>

--- a/public/interfaces
+++ b/public/interfaces
@@ -172,7 +172,7 @@ to work on any <code>geometry</code>.</p>
             <p>The <code>circle</code> and <code>square</code> struct types both
 implement the <code>geometry</code> interface so we can use
 instances of
-these structs as arguments to measure.</p>
+these structs as arguments to `measure.</p>
 
           </td>
           <td class="code">

--- a/public/json
+++ b/public/json
@@ -41,7 +41,7 @@ data types.</p>
             
           </td>
           <td class="code leading">
-	        <a href="http://play.golang.org/p/4L2wMVv7tW"><img title="Run code" src="play.png" class="run" /></a>
+	        <a href="http://play.golang.org/p/scgxBwACYx"><img title="Run code" src="play.png" class="run" /></a>
             <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 
@@ -229,7 +229,7 @@ structure.</p>
           </td>
           <td class="code leading">
 	        
-            <div class="highlight"><pre>    <span class="nx">byt</span> <span class="o">:=</span> <span class="p">[]</span><span class="nb">byte</span><span class="p">(</span><span class="s">`{&quot;num&quot;:6.0,&quot;strs&quot;:[&quot;a&quot;,&quot;b&quot;]}`</span><span class="p">)</span>
+            <div class="highlight"><pre>    <span class="nx">byt</span> <span class="o">:=</span> <span class="p">[]</span><span class="nb">byte</span><span class="p">(</span><span class="s">`{&quot;num&quot;:6.13,&quot;strs&quot;:[&quot;a&quot;,&quot;b&quot;]}`</span><span class="p">)</span>
 </pre></div>
 
           </td>
@@ -361,8 +361,8 @@ stream JSON encodings directly to <code>os.Writer</code>s like
 <span class="go">{&quot;apple&quot;:5,&quot;lettuce&quot;:7}</span>
 <span class="go">{&quot;Page&quot;:1,&quot;Fruits&quot;:[&quot;apple&quot;,&quot;peach&quot;,&quot;pear&quot;]}</span>
 <span class="go">{&quot;page&quot;:1,&quot;fruits&quot;:[&quot;apple&quot;,&quot;peach&quot;,&quot;pear&quot;]}</span>
-<span class="go">map[num:6 strs:[a b]]</span>
-<span class="go">6</span>
+<span class="go">map[num:6.13 strs:[a b]]</span>
+<span class="go">6.13</span>
 <span class="go">a</span>
 <span class="go">&amp;{1 [apple peach]}</span>
 <span class="go">apple</span>


### PR DESCRIPTION
The current example shows `json.Unmarshal` on an array of bytes, including
`num:6.0`. In the output however this comes out as `6`. Even in the casting to
`float64`, it comes out as `6`. This can be confusion because it looks like a
simple `int`. By adding an arbitray `.13` you see it's a
float.

I attempted to only change this in the code example and output, but a lot of other auto generated things came with it and I'm not 100% sure it's needed or not :/ 
