### PR TITLE
Add subtle link back to index

### DIFF
--- a/public/arrays
+++ b/public/arrays
@@ -198,6 +198,9 @@ typical Go. We&rsquo;ll look at slices next.</p>
         Next example: <a href="slices">Slices</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/arrays">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/atomic-counters
+++ b/public/atomic-counters
@@ -212,6 +212,9 @@ state.</p>
         Next example: <a href="mutexes">Mutexes</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/atomic-counters">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/base64-encoding
+++ b/public/base64-encoding
@@ -181,6 +181,9 @@ but they both decode to the original string as desired.</p>
         Next example: <a href="reading-files">Reading Files</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/base64-encoding">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/channel-buffering
+++ b/public/channel-buffering
@@ -145,6 +145,9 @@ concurrent receive.</p>
         Next example: <a href="channel-synchronization">Channel Synchronization</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/channel-buffering">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/channel-directions
+++ b/public/channel-directions
@@ -137,6 +137,9 @@ receive on this channel.</p>
         Next example: <a href="select">Select</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/channel-directions">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/channel-synchronization
+++ b/public/channel-synchronization
@@ -172,6 +172,9 @@ started.</p>
         Next example: <a href="channel-directions">Channel Directions</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/channel-synchronization">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/channels
+++ b/public/channels
@@ -160,6 +160,9 @@ message without having to use any other synchronization.</p>
         Next example: <a href="channel-buffering">Channel Buffering</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/channels">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/closing-channels
+++ b/public/closing-channels
@@ -186,6 +186,9 @@ example: <code>range</code> over channels.</p>
         Next example: <a href="range-over-channels">Range over Channels</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/closing-channels">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/closures
+++ b/public/closures
@@ -182,6 +182,9 @@ recursion.</p>
         Next example: <a href="recursion">Recursion</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/closures">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/collection-functions
+++ b/public/collection-functions
@@ -361,6 +361,9 @@ type.</p>
         Next example: <a href="string-functions">String Functions</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/collection-functions">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/command-line-arguments
+++ b/public/command-line-arguments
@@ -160,6 +160,9 @@ with flags.</p>
         Next example: <a href="command-line-flags">Command-Line Flags</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/command-line-arguments">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/command-line-flags
+++ b/public/command-line-flags
@@ -312,6 +312,9 @@ way to parameterize programs.</p>
         Next example: <a href="environment-variables">Environment Variables</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/command-line-flags">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/constants
+++ b/public/constants
@@ -173,6 +173,9 @@ assignment or function call. For example, here
         Next example: <a href="for">For</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/constants">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/defer
+++ b/public/defer
@@ -185,6 +185,9 @@ after being written.</p>
         Next example: <a href="collection-functions">Collection Functions</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/defer">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/environment-variables
+++ b/public/environment-variables
@@ -176,6 +176,9 @@ program picks that value up.</p>
         Next example: <a href="spawning-processes">Spawning Processes</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/environment-variables">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/epoch
+++ b/public/epoch
@@ -167,6 +167,9 @@ parsing and formatting.</p>
         Next example: <a href="time-formatting-parsing">Time Formatting / Parsing</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/epoch">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/errors
+++ b/public/errors
@@ -289,6 +289,9 @@ on the Go blog for more on error handling.</p>
         Next example: <a href="goroutines">Goroutines</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/errors">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/execing-processes
+++ b/public/execing-processes
@@ -193,6 +193,9 @@ processes covers most use cases for <code>fork</code>.</p>
         Next example: <a href="signals">Signals</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/execing-processes">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/exit
+++ b/public/exit
@@ -164,6 +164,9 @@ the status in the terminal.</p>
       </table>
       
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/exit">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/for
+++ b/public/for
@@ -165,6 +165,9 @@ structures.</p>
         Next example: <a href="if-else">If/Else</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/for">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/functions
+++ b/public/functions
@@ -153,6 +153,9 @@ multiple return values, which we&rsquo;ll look at next.</p>
         Next example: <a href="multiple-return-values">Multiple Return Values</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/functions">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/goroutines
+++ b/public/goroutines
@@ -199,6 +199,9 @@ concurrent Go programs: channels.</p>
         Next example: <a href="channels">Channels</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/goroutines">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/hello-world
+++ b/public/hello-world
@@ -25,7 +25,7 @@
         
         <tr>
           <td class="docs">
-            <p>Our first program will print the classic &ldquo;hello world&rdquo;
+            <p>Our first program will print the classic &ldquo;hello world&rdquo;`
 message. Here&rsquo;s the full source code.</p>
 
           </td>
@@ -131,6 +131,9 @@ learn more about the language.</p>
         Next example: <a href="values">Values</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/hello-world">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/if-else
+++ b/public/if-else
@@ -176,6 +176,9 @@ for basic conditions.</p>
         Next example: <a href="switch">Switch</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/if-else">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/interfaces
+++ b/public/interfaces
@@ -172,7 +172,7 @@ to work on any <code>geometry</code>.</p>
             <p>The <code>circle</code> and <code>square</code> struct types both
 implement the <code>geometry</code> interface so we can use
 instances of
-these structs as arguments to measure.</p>
+these structs as arguments to `measure.</p>
 
           </td>
           <td class="code">
@@ -226,6 +226,9 @@ these structs as arguments to measure.</p>
         Next example: <a href="errors">Errors</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/interfaces">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/json
+++ b/public/json
@@ -393,6 +393,9 @@ for more.</p>
         Next example: <a href="time">Time</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/json">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/line-filters
+++ b/public/line-filters
@@ -196,6 +196,9 @@ lowercase lines.</p>
         Next example: <a href="command-line-arguments">Command-Line Arguments</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/line-filters">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/maps
+++ b/public/maps
@@ -222,6 +222,9 @@ printed with <code>fmt.Println</code>.</p>
         Next example: <a href="range">Range</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/maps">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/methods
+++ b/public/methods
@@ -189,6 +189,9 @@ naming related sets of methods: interfaces.</p>
         Next example: <a href="interfaces">Interfaces</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/methods">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/multiple-return-values
+++ b/public/multiple-return-values
@@ -158,6 +158,9 @@ feature of Go functions; we&rsquo;ll look at this next.</p>
         Next example: <a href="variadic-functions">Variadic Functions</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/multiple-return-values">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/mutexes
+++ b/public/mutexes
@@ -293,6 +293,9 @@ management task using only goroutines and channels.</p>
         Next example: <a href="stateful-goroutines">Stateful Goroutines</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/mutexes">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/non-blocking-channel-operations
+++ b/public/non-blocking-channel-operations
@@ -165,6 +165,9 @@ on both <code>messages</code> and <code>signals</code>.</p>
         Next example: <a href="closing-channels">Closing Channels</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/non-blocking-channel-operations">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/number-parsing
+++ b/public/number-parsing
@@ -203,6 +203,9 @@ bits.</p>
         Next example: <a href="url-parsing">URL Parsing</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/number-parsing">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/panic
+++ b/public/panic
@@ -164,6 +164,9 @@ to use error-indicating return values wherever possible.</p>
         Next example: <a href="defer">Defer</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/panic">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/pointers
+++ b/public/pointers
@@ -185,6 +185,9 @@ the memory address for that variable.</p>
         Next example: <a href="structs">Structs</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/pointers">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/random-numbers
+++ b/public/random-numbers
@@ -210,6 +210,9 @@ that Go can provide.</p>
         Next example: <a href="number-parsing">Number Parsing</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/random-numbers">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/range
+++ b/public/range
@@ -175,6 +175,9 @@ of the <code>rune</code> and the second the <code>rune</code> itself.</p>
         Next example: <a href="functions">Functions</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/range">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/range-over-channels
+++ b/public/range-over-channels
@@ -147,6 +147,9 @@ values be received.</p>
         Next example: <a href="timers">Timers</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/range-over-channels">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/rate-limiting
+++ b/public/rate-limiting
@@ -251,6 +251,9 @@ then serve the remaining 2 with ~200ms delays each.</p>
         Next example: <a href="atomic-counters">Atomic Counters</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/rate-limiting">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/reading-files
+++ b/public/reading-files
@@ -288,6 +288,9 @@ be scheduled immediately after <code>Open</code>ing with
         Next example: <a href="writing-files">Writing Files</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/reading-files">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/recursion
+++ b/public/recursion
@@ -117,6 +117,9 @@ base case of <code>fact(0)</code>.</p>
         Next example: <a href="pointers">Pointers</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/recursion">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/regular-expressions
+++ b/public/regular-expressions
@@ -332,6 +332,9 @@ the <a href="http://golang.org/pkg/regexp/"><code>regexp</code></a> package docs
         Next example: <a href="json">JSON</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/regular-expressions">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/select
+++ b/public/select
@@ -173,6 +173,9 @@ concurrently.</p>
         Next example: <a href="timeouts">Timeouts</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/select">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/sha1-hashes
+++ b/public/sha1-hashes
@@ -193,6 +193,9 @@ you should carefully research
         Next example: <a href="base64-encoding">Base64 Encoding</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/sha1-hashes">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/signals
+++ b/public/signals
@@ -178,6 +178,9 @@ causing the program to print <code>interrupt</code> and then exit.</p>
         Next example: <a href="exit">Exit</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/signals">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/slices
+++ b/public/slices
@@ -300,6 +300,9 @@ Go&rsquo;s other key builtin data structure: maps.</p>
         Next example: <a href="maps">Maps</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/slices">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/sorting
+++ b/public/sorting
@@ -150,6 +150,9 @@ slices and <code>true</code> as the result of our <code>AreSorted</code> test.</
         Next example: <a href="sorting-by-functions">Sorting by Functions</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/sorting">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/sorting-by-functions
+++ b/public/sorting-by-functions
@@ -167,6 +167,9 @@ functions.</p>
         Next example: <a href="panic">Panic</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/sorting-by-functions">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/spawning-processes
+++ b/public/spawning-processes
@@ -249,6 +249,9 @@ as if we had run them directly from the command-line.</p>
         Next example: <a href="execing-processes">Exec'ing Processes</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/spawning-processes">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/stateful-goroutines
+++ b/public/stateful-goroutines
@@ -298,6 +298,9 @@ program.</p>
         Next example: <a href="sorting">Sorting</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/stateful-goroutines">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/string-formatting
+++ b/public/string-formatting
@@ -447,6 +447,9 @@ and returns a string without printing it anywhere.</p>
         Next example: <a href="regular-expressions">Regular Expressions</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/string-formatting">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/string-functions
+++ b/public/string-functions
@@ -193,6 +193,9 @@ and getting a character by index.</p>
         Next example: <a href="string-formatting">String Formatting</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/string-functions">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/structs
+++ b/public/structs
@@ -214,6 +214,9 @@ pointers are automatically dereferenced.</p>
         Next example: <a href="methods">Methods</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/structs">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/switch
+++ b/public/switch
@@ -162,6 +162,9 @@ to express if/else logic. Here we also show how the
         Next example: <a href="arrays">Arrays</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/switch">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/tickers
+++ b/public/tickers
@@ -143,6 +143,9 @@ before we stop it.</p>
         Next example: <a href="worker-pools">Worker Pools</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/tickers">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/time
+++ b/public/time
@@ -260,6 +260,9 @@ the Unix epoch.</p>
         Next example: <a href="epoch">Epoch</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/time">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/time-formatting-parsing
+++ b/public/time-formatting-parsing
@@ -212,6 +212,9 @@ use for both formatting and parsing.</p>
         Next example: <a href="random-numbers">Random Numbers</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/time-formatting-parsing">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/timeouts
+++ b/public/timeouts
@@ -183,6 +183,9 @@ examples of this next: timers and tickers.</p>
         Next example: <a href="non-blocking-channel-operations">Non-Blocking Channel Operations</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/timeouts">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/timers
+++ b/public/timers
@@ -160,6 +160,9 @@ a chance to expire.</p>
         Next example: <a href="tickers">Tickers</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/timers">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/url-parsing
+++ b/public/url-parsing
@@ -226,6 +226,9 @@ pieces that we extracted.</p>
         Next example: <a href="sha1-hashes">SHA1 Hashes</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/url-parsing">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/values
+++ b/public/values
@@ -144,6 +144,9 @@ basic examples.</p>
         Next example: <a href="variables">Variables</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/values">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/variables
+++ b/public/variables
@@ -175,6 +175,9 @@ initializing a variable, e.g. for
         Next example: <a href="constants">Constants</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/variables">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/variadic-functions
+++ b/public/variadic-functions
@@ -164,6 +164,9 @@ to form closures, which we&rsquo;ll look at next.</p>
         Next example: <a href="closures">Closures</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/variadic-functions">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/worker-pools
+++ b/public/worker-pools
@@ -208,6 +208,9 @@ there are 3 workers operating concurrently.</p>
         Next example: <a href="rate-limiting">Rate Limiting</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/worker-pools">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/public/writing-files
+++ b/public/writing-files
@@ -279,6 +279,9 @@ we&rsquo;ve just seen to the <code>stdin</code> and <code>stdout</code> streams.
         Next example: <a href="line-filters">Line Filters</a>.
       </p>
       
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/writing-files">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>

--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -40,6 +40,9 @@
         Next example: <a href="{{.NextExample.Id}}">{{.NextExample.Name}}</a>.
       </p>
       {{end}}
+      <p class="next">
+        Or go back to the <a href="/">Index</a>.
+      </p>
       <p class="footer">
         by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/{{.Id}}">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
       </p>


### PR DESCRIPTION
I've been working through these, but not necessarily in order. Sometimes I hop around, doing 2 or 3 in a row, and them I'm away from the index.

This adds a link back to [the Index](https://gobyexample.com) page under the `Next example [...]` link:

![index link](http://cl.ly/image/3h413d3L2R0I/data)

I'm not attached to the wording, so suggestions welcome there. 

This commit is both the link and the resulting changes in `public` after running `tools/build`. The actual code change is in the `templates` folder: https://github.com/mmcgrana/gobyexample/pull/70/files#diff-65

The [README](https://github.com/mmcgrana/gobyexample/blob/master/README.md) doesn't mention if that should be the case. Since they are generated files, I would think they aren't to be tracked at all, but that may depend on how you're deploying the result... 
