### PR TITLE
Adding call to check(err) after os.Open

### DIFF
--- a/examples/reading-files/reading-files.go
+++ b/examples/reading-files/reading-files.go
@@ -32,7 +32,8 @@ func main() {
     // parts of a file are read. For these tasks, start
     // by `Open`ing a file to obtain an `os.File` value.
     f, err := os.Open("/tmp/dat")
-
+    check(err)
+    
     // Read some bytes from the beginning of the file.
     // Allow up to 5 to be read but also note how many
     // actually were read.


### PR DESCRIPTION
Clearly we were just able to read the content via ioutil.ReadFile but for consistency I think it would be better to call check(err) after the call to os.Open("/tmp/dat") on line 34.

Tools like errcheck (https://github.com/kisielk/errcheck) will complain about uncaught / unhandled err's. Also can we really be sure some 3rd party process didn't nuke '/tmp' during execution :-)
