### PR TITLE
elide obsolete tab flags

### DIFF
--- a/tools/gofmt
+++ b/tools/gofmt
@@ -3,4 +3,4 @@
 set -e
 set -o pipefail
 
-ls tools/*.go examples/*/*.go | xargs gofmt -tabs=false -tabwidth=4 -w=true
+ls tools/*.go examples/*/*.go | xargs gofmt -w=true


### PR DESCRIPTION
removed `tabs` and `tabwidth` flags from `tools/gofmt` so that `tools/build` will work.
