### PR TITLE
Fix comment on rand example.

### DIFF
--- a/examples/random-numbers/random-numbers.go
+++ b/examples/random-numbers/random-numbers.go
@@ -30,7 +30,7 @@ func main() {
     s1 := rand.NewSource(42)
     r1 := rand.New(s1)
 
-    // Call the resulting `rand.Source` just like the
+    // Call the resulting `rand.Rand` just like the
     // functions on the `rand` package.
     fmt.Print(r1.Intn(100), ",")
     fmt.Print(r1.Intn(100))


### PR DESCRIPTION
Example shows methods being called on r1 (type Rand) not s1 (type Source).  Fix comment to reflect this correctly.