### PR TITLE
using html5 meta charset tag

### DIFF
--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-eqiv="content-type" content="text/html;charset=utf-8">
+    <meta charset="utf-8">
     <title>Go by Example: {{.Name}}</title>
     <link rel=stylesheet href="site.css">
   </head>

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-eqiv="content-type" content="text/html;charset=utf-8">
+    <meta charset="utf-8">
     <title>Go by Example</title>
     <link rel=stylesheet href="site.css">
   </head>


### PR DESCRIPTION
The html doctype is html5 but the meta charset is not, so make some minor change to prevent some charset detect problem. my Ngnix and Firefox meet this problem.