### PR TITLE
Added call to runtime.Gosched() to goroutines

### DIFF
--- a/examples/goroutines/goroutines.go
+++ b/examples/goroutines/goroutines.go
@@ -2,11 +2,23 @@
 
 package main
 
-import "fmt"
+import (
+    "fmt"
+    "runtime"
+)
 
 func f(from string) {
     for i := 0; i < 3; i++ {
         fmt.Println(from, ":", i)
+
+        // The reason to call `runtime.GoSched()` is to transfer
+        // execution to the next goroutine. This is necessary when
+        // Go runs in a single system thread, since in that case
+        // it won't yield to another goroutine unless asked for
+        // with an explicit call as below or during a system call.
+        // It's also possible to set the max number of system
+        // threads with the `GOMAXPROCS` environment variable.
+        runtime.Gosched()
     }
 }
 

--- a/examples/goroutines/goroutines.go
+++ b/examples/goroutines/goroutines.go
@@ -11,12 +11,12 @@ func f(from string) {
     for i := 0; i < 3; i++ {
         fmt.Println(from, ":", i)
 
-        // The reason to call `runtime.GoSched()` is to transfer
-        // execution to the next goroutine. This is necessary when
-        // Go runs in a single system thread, since in that case
-        // it won't yield to another goroutine unless asked for
-        // with an explicit call as below or during a system call.
-        // It's also possible to set the max number of system
+        // `runtime.GoSched()` transfers execution to the next
+        // goroutine. Since goroutines are multiplexed across
+        // system threads, if there's only one thread it won't
+        // yield to another goroutine unless asked explicitly
+        // as with the call as below or during a system call.
+        // Note that you can control the number of system
         // threads with the `GOMAXPROCS` environment variable.
         runtime.Gosched()
     }


### PR DESCRIPTION
With an explanation for why you may need it in order to observe interleaved execution. Fixes #103

Not sure if this is clear or just complicates the example, but I imagine some people are confused when they run the sample code and don't see the expected outcome.
