### PR TITLE
Per platform 'sed' command to format files to have 4 spaces (darwin and linux supported)

### DIFF
--- a/tools/format
+++ b/tools/format
@@ -4,7 +4,24 @@ set -eo pipefail
 
 paths=$(ls tools/*.go examples/*/*.go)
 
+gbe_to_4spaces() {
+  local os=$(tr [A-Z] [a-z] <<< "`uname`")
+  case $os in
+    darwin*)
+      sed -i '' -e 's/	/    /g' $1
+      ;;
+    linux*)
+      sed -i -e 's/	/    /g' $1
+      ;;
+    *)
+      echo "$os is not supported."
+      echo "Add a proper 'sed' command for your platform to ./tools/format"
+      return 1
+      ;;
+  esac
+}
+
 for path in $paths; do
   gofmt -w=true $path
-  sed -i '' -e 's/	/    /g' $path
+  gbe_to_4spaces $path
 done


### PR DESCRIPTION
Based on the comments on [this commit](https://github.com/mmcgrana/gobyexample/commit/8e7a6bb08685033cddff20f626896fd269b403b7) I added conditional `sed` commands since syntax is different among OSs and this wasn't working on Linux, other people might add their own platforms by adding more cases. 
