### PR TITLE
slices: add an example

### DIFF
--- a/examples/slices/slices.go
+++ b/examples/slices/slices.go
@@ -56,6 +56,13 @@ func main() {
     l = s[2:]
     fmt.Println("sl3:", l)
 
+    // When you create a slice using the "slice" operator
+    // note that any changes to the new slice will also
+    // change the old slice
+    l[0] = "Z"
+    fmt.Println("l[0]:", l)
+    fmt.Println("s[2]:", s[2])
+
     // We can declare and initialize a variable for slice
     // in a single line as well.
     t := []string{"g", "h", "i"}

--- a/examples/slices/slices.hash
+++ b/examples/slices/slices.hash
@@ -1,2 +1,2 @@
-d900c3b1cf2bd96591f7ad7ce7fd9e592ec31139
-dPQErsP6Yc
+2596da330b7ab2333e39ca0c7dc68c9c86fa9c3a
+Nih7oG7cYC

--- a/examples/slices/slices.sh
+++ b/examples/slices/slices.sh
@@ -10,6 +10,8 @@ cpy: [a b c d e f]
 sl1: [c d e]
 sl2: [a b c d e]
 sl3: [c d e f]
+l[0]: [Z d e f]
+s[2]: Z
 dcl: [g h i]
 2d:  [[0] [1 2] [2 3 4]]
 


### PR DESCRIPTION
This commit adds an example to the slices examples to demonstrate that when a slice is created from an underlying slice, any changes to the new slice will also be reflected in the original slice.
