### PR TITLE
Error checking in examples/reading-files

### DIFF
--- a/examples/reading-files/reading-files.go
+++ b/examples/reading-files/reading-files.go
@@ -14,9 +14,13 @@ import (
 
 // Reading files requires checking most calls for errors.
 // This helper will streamline our error checks below.
-func check(e error) {
-    if e != nil {
-        panic(e)
+// Printing an error and then exiting is an appropriate way
+// to handle errors at the top level of a command line
+// program, but not in general purpose library functions.
+func check(err error) {
+    if err != nil {
+        fmt.Println("Fatal:", err)
+        os.Exit(1)
     }
 }
 
@@ -76,9 +80,12 @@ func main() {
     check(err)
     fmt.Printf("5 bytes: %s\n", string(b4))
 
-    // Close the file when you're done (usually this would
+    // Close the file when you're done - usually this would
     // be scheduled immediately after `Open`ing with
-    // `defer`).
-    f.Close()
+    // `defer`, but we can't do that when writing to a file.
+    // We need error checking here because a write error may
+    // not show up until a file is flushed and closed.
+    err = f.Close()
+    check(err)
 
 }

--- a/examples/reading-files/reading-files.hash
+++ b/examples/reading-files/reading-files.hash
@@ -1,2 +1,2 @@
-2aa7a2e248065cebfa6f8eece3234b5ffa710273
-2kEKXq-kUV
+26a8e3baac3ec30043f6aab96b15c542986c3679
+kRTLYdhgTj


### PR DESCRIPTION
This improves the error checking in in this example by clarifying that
the check() pattern should be limited to the top level of command line
programs, avoiding the full panic backtrace, and checking the return of
close() at the end. I think this better reflects current practices,
although I'm tempted to remove the check() function at all and provide
more useful error messages at each exit point - although this may make
the example too cluttered.

(I think I got it right with the formatting and hash thing, although
this was a slight fight against my editor - why not standardize on
gofmt:ed code like the rest of the Go universe? ;)