### PR TITLE
Add sleep in atomic-counter to make it run ~1 time/ms

### DIFF
--- a/examples/atomic-counters/atomic-counters.go
+++ b/examples/atomic-counters/atomic-counters.go
@@ -29,6 +29,7 @@ func main() {
                 // address of our `ops` counter with the
                 // `&` syntax.
                 atomic.AddUint64(&ops, 1)
+                time.Sleep(time.Millisecond)
 
                 // Allow other goroutines to proceed.
                 runtime.Gosched()


### PR DESCRIPTION
As written, the atomic-counter example runs in a tight loop, saturating all CPU cores and returning a very high value:

```
$ go run atomic-counters.go
ops: 5159303
```

The comment mentions running approximately, once a millisecond for which the code has no such constraint.  I added an explicit `time.Sleep(time.Millisecond)` here and now the correct value is returned:

```
$ go run atomic-counters.go
ops: 40350
```

@mmcgrana thanks so much for building this.  It has been a great introduction to Go for me! 💯 
