### PR TITLE
Fix typo in the command line flags example.

### DIFF
--- a/examples/command-line-flags/command-line-flags.sh
+++ b/examples/command-line-flags/command-line-flags.sh
@@ -49,7 +49,7 @@ Usage of ./command-line-flags:
 
 # If you provide a flag that wasn't specified to the
 # `flag` package, the program will print an error message
-# an show the help text again.
+# and show the help text again.
 $ ./command-line-flags -wat
 flag provided but not defined: -wat
 Usage of ./command-line-flags:


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mmcgrana/gobyexample/146)

<!-- Reviewable:end -->
