### PR TITLE
Add clarification about index and length of string

### DIFF
--- a/examples/string-functions/string-functions.go
+++ b/examples/string-functions/string-functions.go
@@ -41,3 +41,11 @@ func main() {
     p("Len: ", len("hello"))
     p("Char:", "hello"[1])
 }
+
+// *NOTE - Getting the index of a string technically gets that byte,
+// and not necessarily the character (as in multi-byte unicode characters).
+// The length of a string is its length in bytes, and not necessarily
+// the length in characters.
+// You could get a character by the index of a rune slice, or by
+// using a range loop.*
+// You can read more [Here](https://blog.golang.org/strings).


### PR DESCRIPTION
Adding a note to `string-functions.go` that explains that the index of a string is actually a byte of that string, and the length of a string is the length in bytes; not characters which would only technically work for ASCII characters in the string.  A link is provided to the applicable blog post.