### PR TITLE
Corrected spelling mistake

### DIFF
--- a/public/goroutines
+++ b/public/goroutines
@@ -159,7 +159,7 @@ before the program exits.</p>
           <td class="docs">
             <p>When we run this program, we see the output of the
 blocking call first, then the interleaved output of the
-two gouroutines. This interleaving reflects the
+two goroutines. This interleaving reflects the
 goroutines being run concurrently by the Go runtime.</p>
 
           </td>


### PR DESCRIPTION
Corrected "gouroutines" with "goroutines".