### PR TITLE
Adding explanation to the non-blocking send example

### DIFF
--- a/examples/non-blocking-channel-operations/non-blocking-channel-operations.go
+++ b/examples/non-blocking-channel-operations/non-blocking-channel-operations.go
@@ -22,7 +22,14 @@ func main() {
         fmt.Println("no message received")
     }
 
-    // A non-blocking send works similarly.
+    // A non-blocking send works similarly. Here `msg`
+    // cannot be sent to the `messages` channel, because
+    // the channel has no buffer and there is no receiver.
+    // Therefore, the default case is selected.
+    //
+    // To allow `msg` to be sent, either add a buffer
+    // to the `messages` channel or add a goroutine that
+    // receives from it.
     msg := "hi"
     select {
     case messages <- msg:


### PR DESCRIPTION
Adding documentation to the non-blocking send example to explain:
- Why the send is prevented
- How to adjust the code to to allow the send
