### PR TITLE
"t declared and not used" fix

### DIFF
--- a/examples/switch/switch.go
+++ b/examples/switch/switch.go
@@ -43,10 +43,9 @@ func main() {
 
     // A type `switch` compares types instead of values.  You
     // can use this to discover the the type of an interface
-    // value.  In this example, the variable `t` will have the
-    // type corresponding to its clause.
+    // value. 
     whatAmI := func(i interface{}) {
-        switch t := i.(type) {
+        switch i.(type) {
         case bool:
             fmt.Println("I'm a bool")
         case int:


### PR DESCRIPTION
In the latest function, the switch body (line 48) causes a compiler warning "t declared and not used" 
If I make the corresponding change from switch i := i.(type) to switch i.(type), it compiles without any issues.