### PR TITLE
Remove duplicate `the` in `switch` page

### DIFF
--- a/examples/switch/switch.go
+++ b/examples/switch/switch.go
@@ -42,7 +42,7 @@ func main() {
     }
 
     // A type `switch` compares types instead of values.  You
-    // can use this to discover the the type of an interface
+    // can use this to discover the type of an interface
     // value.  In this example, the variable `t` will have the
     // type corresponding to its clause.
     whatAmI := func(i interface{}) {


### PR DESCRIPTION
Remove double `the`