### PR TITLE
BIOS script to check lint, vet and build success

### DIFF
--- a/bios.sh
+++ b/bios.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+
+mkdir -p src/$PKG && cd src/$PKG
+run -s "Cloning"  git clone $URL --branch $REF --single-branch .
+git reset --hard $SHA
+
+PKGS=$(go list $PKG/...)
+run -s "Linting"  golint -set_exit_status $PKGS
+run -s "Vetting"  go vet -x $PKGS
+run -s "Building" go build -v $PKGS
+run -s "Testing"  go test -v $PKGS

--- a/bios.sh
+++ b/bios.sh
@@ -5,8 +5,10 @@ mkdir -p src/$PKG && cd src/$PKG
 run -s "Cloning"  git clone $URL --branch $REF --single-branch .
 git reset --hard $SHA
 
-PKGS=$(go list $PKG/...)
+go get github.com/russross/blackfriday
+
+PKGS=$(go list $PKG/... | grep -v examples)
 run -s "Linting"  golint -set_exit_status $PKGS
 run -s "Vetting"  go vet -x $PKGS
-run -s "Building" go build -v $PKGS
+run -s "Building" tools/build
 run -s "Testing"  go test -v $PKGS

--- a/bios.sh
+++ b/bios.sh
@@ -11,4 +11,3 @@ PKGS=$(go list $PKG/... | grep -v examples)
 run -s "Linting"  golint -set_exit_status $PKGS
 run -s "Vetting"  go vet -x $PKGS
 run -s "Building" tools/build
-run -s "Testing"  go test -v $PKGS

--- a/tools/generate.go
+++ b/tools/generate.go
@@ -118,12 +118,14 @@ func debug(msg string) {
 var docsPat = regexp.MustCompile("^\\s*(\\/\\/|#)\\s")
 var dashPat = regexp.MustCompile("\\-+")
 
+// Seg is a segment of an example
 type Seg struct {
     Docs, DocsRendered              string
     Code, CodeRendered              string
     CodeEmpty, CodeLeading, CodeRun bool
 }
 
+// Example is info extracted from an example file
 type Example struct {
     Id, Name                    string
     GoCode, GoCodeHash, UrlHash string

--- a/tools/generate.go
+++ b/tools/generate.go
@@ -128,7 +128,7 @@ type Seg struct {
 // Example is info extracted from an example file
 type Example struct {
     ID, Name                    string
-    GoCode, GoCodeHash, UrlHash string
+    GoCode, GoCodeHash, URLHash string
     Segs                        [][]*Seg
     NextExample                 *Example
 }
@@ -138,7 +138,7 @@ func parseHashFile(sourcePath string) (string, string) {
     return lines[0], lines[1]
 }
 
-func resetUrlHashFile(codehash, code, sourcePath string) string {
+func resetURLHashFile(codehash, code, sourcePath string) string {
     payload := strings.NewReader(code)
     resp, err := http.Post("https://play.golang.org/share", "text/plain", payload)
     if err != nil {
@@ -232,7 +232,7 @@ func parseExamples() []*Example {
             sourcePaths := mustGlob("examples/" + exampleID + "/*")
             for _, sourcePath := range sourcePaths {
                 if strings.HasSuffix(sourcePath, ".hash") {
-                    example.GoCodeHash, example.UrlHash = parseHashFile(sourcePath)
+                    example.GoCodeHash, example.URLHash = parseHashFile(sourcePath)
                 } else {
                     sourceSegs, filecontents := parseAndRenderSegs(sourcePath)
                     if filecontents != "" {
@@ -243,7 +243,7 @@ func parseExamples() []*Example {
             }
             newCodeHash := sha1Sum(example.GoCode)
             if example.GoCodeHash != newCodeHash {
-                example.UrlHash = resetUrlHashFile(newCodeHash, example.GoCode, "examples/"+example.ID+"/"+example.ID+".hash")
+                example.URLHash = resetURLHashFile(newCodeHash, example.GoCode, "examples/"+example.ID+"/"+example.ID+".hash")
             }
             examples = append(examples, &example)
         }

--- a/tools/generate.go
+++ b/tools/generate.go
@@ -127,7 +127,7 @@ type Seg struct {
 
 // Example is info extracted from an example file
 type Example struct {
-    Id, Name                    string
+    ID, Name                    string
     GoCode, GoCodeHash, UrlHash string
     Segs                        [][]*Seg
     NextExample                 *Example
@@ -222,14 +222,14 @@ func parseExamples() []*Example {
     for _, exampleName := range exampleNames {
         if (exampleName != "") && !strings.HasPrefix(exampleName, "#") {
             example := Example{Name: exampleName}
-            exampleId := strings.ToLower(exampleName)
-            exampleId = strings.Replace(exampleId, " ", "-", -1)
-            exampleId = strings.Replace(exampleId, "/", "-", -1)
-            exampleId = strings.Replace(exampleId, "'", "", -1)
-            exampleId = dashPat.ReplaceAllString(exampleId, "-")
-            example.Id = exampleId
+            exampleID := strings.ToLower(exampleName)
+            exampleID = strings.Replace(exampleID, " ", "-", -1)
+            exampleID = strings.Replace(exampleID, "/", "-", -1)
+            exampleID = strings.Replace(exampleID, "'", "", -1)
+            exampleID = dashPat.ReplaceAllString(exampleID, "-")
+            example.ID = exampleID
             example.Segs = make([][]*Seg, 0)
-            sourcePaths := mustGlob("examples/" + exampleId + "/*")
+            sourcePaths := mustGlob("examples/" + exampleID + "/*")
             for _, sourcePath := range sourcePaths {
                 if strings.HasSuffix(sourcePath, ".hash") {
                     example.GoCodeHash, example.UrlHash = parseHashFile(sourcePath)
@@ -243,7 +243,7 @@ func parseExamples() []*Example {
             }
             newCodeHash := sha1Sum(example.GoCode)
             if example.GoCodeHash != newCodeHash {
-                example.UrlHash = resetUrlHashFile(newCodeHash, example.GoCode, "examples/"+example.Id+"/"+example.Id+".hash")
+                example.UrlHash = resetUrlHashFile(newCodeHash, example.GoCode, "examples/"+example.ID+"/"+example.ID+".hash")
             }
             examples = append(examples, &example)
         }
@@ -270,7 +270,7 @@ func renderExamples(examples []*Example) {
     _, err := exampleTmpl.Parse(mustReadFile("templates/example.tmpl"))
     check(err)
     for _, example := range examples {
-        exampleF, err := os.Create(siteDir + "/" + example.Id)
+        exampleF, err := os.Create(siteDir + "/" + example.ID)
         check(err)
         exampleTmpl.Execute(exampleF, example)
     }

--- a/tools/generate.go
+++ b/tools/generate.go
@@ -106,7 +106,6 @@ func whichLexer(path string) string {
         return "console"
     }
     panic("No lexer for " + path)
-    return ""
 }
 
 func debug(msg string) {


### PR DESCRIPTION
This adds a [BIOS script](https://www.mixable.net/docs/bios/) that verifies every PR passes go lint, vet and build commands.

See https://github.com/nzoschke/gobyexample/pull/1 for a demo of the status check passing.

Currently lint and vet ignore the examples folder as examples like variables.go have intentionally verbose code for demonstration purposes.

See https://github.com/nzoschke/gobyexample/pull/2 for changes to examples to make lint and vet happier.

