### PR TITLE
Verify the checked-in build

### DIFF
--- a/bios.sh
+++ b/bios.sh
@@ -15,3 +15,5 @@ PKGS=$(go list $PKG/... | grep -v examples/panic)
 run -s "Vetting"  go vet -x $PKGS
 
 run -s "Building" tools/build
+
+run -s "Verifying" git diff --exit-code


### PR DESCRIPTION
Extend bios.sh to ensure that the there are no changes in
the build-time git repo after `tools/build` has been run.
This ensures that the checked-in .go and .sh sources match
the check-in public/ files.