### PR TITLE
update constants.go

### DIFF
--- a/examples/constants/constants.go
+++ b/examples/constants/constants.go
@@ -22,7 +22,7 @@ func main() {
     fmt.Println(d)
 
     // A numeric constant has no type until it's given
-    // one, such as by an explicit cast.
+    // one, such as by an explicit conversion.
     fmt.Println(int64(d))
 
     // A number can be given a type by using it in a


### PR DESCRIPTION
I'm a real newbie to Go, but my teacher was telling me the other day that Go refers to 'casting' as 'conversion' and that you actually won't find the word 'cast' anywhere in the language spec for that reason. So I thought maybe it might be an idea to make that same change in how you refer to it in gobyexample?