### PR TITLE
Fix channel-synchronization example : channel buffer

### DIFF
--- a/examples/channel-synchronization/channel-synchronization.go
+++ b/examples/channel-synchronization/channel-synchronization.go
@@ -23,7 +23,7 @@ func main() {
 
     // Start a worker goroutine, giving it the channel to
     // notify on.
-    done := make(chan bool, 1)
+    done := make(chan bool)
     go worker(done)
 
     // Block until we receive a notification from the

--- a/examples/channel-synchronization/channel-synchronization.hash
+++ b/examples/channel-synchronization/channel-synchronization.hash
@@ -1,2 +1,2 @@
 fe3e2ea1a67d0f95ce4cb18f3e8aa16d416de0ce
-0DfW-1RMqi
+TUgesSjKc95

--- a/public/channel-synchronization
+++ b/public/channel-synchronization
@@ -41,7 +41,7 @@ blocking receive to wait for a goroutine to finish.</p>
             
           </td>
           <td class="code leading">
-	        <a href="http://play.golang.org/p/0DfW-1RMqi"><img title="Run code" src="play.png" class="run" /></a>
+	        <a href="http://play.golang.org/p/TUgesSjKc95"><img title="Run code" src="play.png" class="run" /></a>
             <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 


### PR DESCRIPTION
In this case, channer buffer is not neccessary
Because without channel buffering, receiver wait for a spawned groutine finish.