### PR TITLE
Added warning for capital field names in structs

### DIFF
--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -14,8 +14,8 @@ type response1 struct {
     Page   int
     Fruits []string
 }
-// Fields must have capital letters to be exposed to other
-// programs such as the JSON Marshaller. 
+// Only exported fields will be encoded/decoded in JSON. 
+// Fields must start with capital letters to be exported.
 type response2 struct {
     Page   int      `json:"page"`
     Fruits []string `json:"fruits"`

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -14,6 +14,8 @@ type response1 struct {
     Page   int
     Fruits []string
 }
+// Fields must have capital letters to be exposed to other
+// programs such as the JSON Marshaller. 
 type response2 struct {
     Page   int      `json:"page"`
     Fruits []string `json:"fruits"`


### PR DESCRIPTION
Names without capital letters will be ignored by the JSON Marshaller. This may cause confusion when fields are not being unmarshalled correctly without a warning why.