### PR TITLE
Change example text in variables.go

### DIFF
--- a/examples/variables/variables.go
+++ b/examples/variables/variables.go
@@ -28,7 +28,7 @@ func main() {
 
     // The `:=` syntax is shorthand for declaring and
     // initializing a variable, e.g. for
-    // `var f string = "short"` in this case.
-    f := "short"
+    // `var f string = "apple"` in this case.
+    f := "apple"
     fmt.Println(f)
 }


### PR DESCRIPTION
Instead of `short`, which is a common programming language keyword (representing the `short` data type in many languages), use something random like 'apple'.

When I first read this in the example, I thought it was creating a variable of type `short`. It took me a few seconds to realize that the example was showing the declaration of a string, not a short.

While it may just be me (brain fart), hopefully this change would help prevent confusion when reading about variable declarations, especially when the string's value is a common type (but a type that's not in Go).

If it's not worth it, and we leave totally as is, no worries. Just an idea.