### PR TITLE
corrected output for last example

### DIFF
--- a/public/variables
+++ b/public/variables
@@ -150,7 +150,7 @@ initializing a variable, e.g. for
 <span class="go">1 2</span>
 <span class="go">true</span>
 <span class="go">0</span>
-<span class="go">short</span>
+<span class="go">apple</span>
 </pre></div>
 
           </td>


### PR DESCRIPTION
Fixed typo for exercise [Variables](https://gobyexample.com/variables) on the example output for the last example:
```golang
f := "apple"
fmt.Println(f)
```
Expected output: `apple`
Actual output: `short`