### PR TITLE
Fix an incorrect textual reference

### DIFF
--- a/examples/command-line-flags/command-line-flags.sh
+++ b/examples/command-line-flags/command-line-flags.sh
@@ -54,6 +54,3 @@ $ ./command-line-flags -wat
 flag provided but not defined: -wat
 Usage of ./command-line-flags:
 ...
-
-# Next we'll look at environment variables, another common
-# way to parameterize programs.

--- a/examples/command-line-subcommands/command-line-subcommands.sh
+++ b/examples/command-line-subcommands/command-line-subcommands.sh
@@ -19,3 +19,6 @@ flag provided but not defined: -enable
 Usage of bar:
   -level int
     	level
+
+# Next we'll look at environment variables, another common
+# way to parameterize programs.

--- a/public/command-line-flags
+++ b/public/command-line-flags
@@ -272,7 +272,7 @@ generated help text for the command-line program.</p>
 and show the help text again.</p>
 
           </td>
-          <td class="code leading">
+          <td class="code">
             
             <div class="highlight"><pre><span class="gp">$</span> ./command-line-flags -wat
 <span class="go">flag provided but not defined: -wat</span>
@@ -280,18 +280,6 @@ and show the help text again.</p>
 <span class="go">...</span>
 </pre></div>
 
-          </td>
-        </tr>
-        
-        <tr>
-          <td class="docs">
-            <p>Next we&rsquo;ll look at environment variables, another common
-way to parameterize programs.</p>
-
-          </td>
-          <td class="code empty">
-            
-            
           </td>
         </tr>
         

--- a/public/command-line-subcommands
+++ b/public/command-line-subcommands
@@ -214,7 +214,7 @@ have access to trailing positional arguments.</p>
             <p>But bar won&rsquo;t accept foo&rsquo;s flags.</p>
 
           </td>
-          <td class="code">
+          <td class="code leading">
             
             <div class="highlight"><pre><span class="gp">$</span> ./command-line-subcommands bar -enable a1
 <span class="go">flag provided but not defined: -enable</span>
@@ -223,6 +223,18 @@ have access to trailing positional arguments.</p>
 <span class="go">        level</span>
 </pre></div>
 
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            <p>Next we&rsquo;ll look at environment variables, another common
+way to parameterize programs.</p>
+
+          </td>
+          <td class="code empty">
+            
+            
           </td>
         </tr>
         


### PR DESCRIPTION
The command-line-flags page referenced environment variables as the next page in the text, but the actual next page was command-line-subcommands.  This PR just moves that text to the command-line-subcommands page.