### PR TITLE
When testing on Travis, verify that tools/build was run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
 
 env:
   - VERBOSE=1
+  - TESTING=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ script:
   - tools/build
 
 env:
-  - VERBOSE=1
-  - TESTING=1
+  - VERBOSE=1 TESTING=1

--- a/tools/build
+++ b/tools/build
@@ -15,5 +15,27 @@ tools/format
 verbose && echo "Measuring line lengths..."
 tools/measure
 
-verbose && echo "Generating HTML..."
-tools/generate
+# SITE_DIR is the final location where we want generated content to be
+SITE_DIR="public"
+
+# GENERATE_DIR is where the content will be generated initially
+GENERATE_DIR="$(mktemp -d)"
+
+function cleanup() {
+  rm -rf "$GENERATE_DIR"
+}
+trap cleanup EXIT
+
+verbose && echo "Generating HTML to $GENERATE_DIR..."
+tools/generate $GENERATE_DIR
+
+# In TESTING mode, make sure that the generated content is identical to
+# what's already in SITE_DIR. If a difference is found, this script exits
+# with an error.
+if [[ ! -z "$TESTING" ]]; then
+	echo "Comparing $GENERATE_DIR with $SITE_DIR..."
+	diff -r "$GENERATE_DIR" "$SITE_DIR"
+fi
+
+verbose && echo "Copying $GENERATE_DIR to $SITE_DIR"
+cp -rf "${GENERATE_DIR}/." "$SITE_DIR"

--- a/tools/generate
+++ b/tools/generate
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec go run tools/generate.go
+exec go run tools/generate.go $@

--- a/tools/generate.go
+++ b/tools/generate.go
@@ -15,8 +15,12 @@ import (
 	"github.com/russross/blackfriday"
 )
 
-var cacheDir = "/tmp/gobyexample-cache"
+// siteDir is the target directory into which the HTML gets generated. Its
+// default is set here but can be changed by an argument passed into the
+// program.
 var siteDir = "./public"
+
+var cacheDir = "/tmp/gobyexample-cache"
 var pygmentizeBin = "./vendor/pygments/pygmentize"
 
 func verbose() bool {
@@ -301,6 +305,11 @@ func renderExamples(examples []*Example) {
 }
 
 func main() {
+	if len(os.Args) > 1 {
+		siteDir = os.Args[1]
+	}
+	ensureDir(siteDir)
+
 	copyFile("templates/site.css", siteDir+"/site.css")
 	copyFile("templates/favicon.ico", siteDir+"/favicon.ico")
 	copyFile("templates/404.html", siteDir+"/404.html")


### PR DESCRIPTION
This is done by routing the generation of HTML into a temporary directory,
and checking its diff agains the existing public/ when running tests.

Fixes #237