### PR TITLE
Fix up language attribution for the Github UI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+public/* linguist-generated=true
+vendor/* linguist-vendored=true
+


### PR DESCRIPTION
Currently gobyexample is flagged as a CSS repository because of all the
generated HTML.

Following instructions at https://github.com/github/linguist#vendored-code to
ask Github to ignore files that are not actual origin code.