### PR TITLE
Clarify use of buffered channel in the timeouts example.

### DIFF
--- a/examples/timeouts/timeouts.go
+++ b/examples/timeouts/timeouts.go
@@ -12,7 +12,10 @@ func main() {
 
 	// For our example, suppose we're executing an external
 	// call that returns its result on a channel `c1`
-	// after 2s.
+	// after 2s. Note that the channel is buffered, so the
+	// send in the goroutine is nonblocking. This is a
+	// common pattern to prevent goroutine leaks in case the
+	// channel is never read.
 	c1 := make(chan string, 1)
 	go func() {
 		time.Sleep(2 * time.Second)

--- a/examples/timeouts/timeouts.hash
+++ b/examples/timeouts/timeouts.hash
@@ -1,2 +1,2 @@
-93343e1aacb14f818c87732914c29ba57afab245
-MgcfA-xpJO9
+b1e8d0efbabd0c52271a85fad5ad58dcd1c7c476
+gyY_qDsRVUe

--- a/examples/timeouts/timeouts.sh
+++ b/examples/timeouts/timeouts.sh
@@ -3,9 +3,3 @@
 $ go run timeouts.go 
 timeout 1
 result 2
-
-# Using this `select` timeout pattern requires
-# communicating results over channels. This is a good
-# idea in general because other important Go features are
-# based on channels and `select`. We'll look at two
-# examples of this next: timers and tickers.

--- a/public/timeouts
+++ b/public/timeouts
@@ -44,7 +44,7 @@ elegant thanks to channels and <code>select</code>.</p>
             
           </td>
           <td class="code leading">
-            <a href="http://play.golang.org/p/MgcfA-xpJO9"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
+            <a href="http://play.golang.org/p/gyY_qDsRVUe"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
           <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 
@@ -80,7 +80,10 @@ elegant thanks to channels and <code>select</code>.</p>
           <td class="docs">
             <p>For our example, suppose we&rsquo;re executing an external
 call that returns its result on a channel <code>c1</code>
-after 2s.</p>
+after 2s. Note that the channel is buffered, so the
+send in the goroutine is nonblocking. This is a
+common pattern to prevent goroutine leaks in case the
+channel is never read.</p>
 
           </td>
           <td class="code leading">

--- a/public/timeouts
+++ b/public/timeouts
@@ -156,28 +156,13 @@ from <code>c2</code> will succeed and we&rsquo;ll print the result.</p>
 out and the second succeeding.</p>
 
           </td>
-          <td class="code leading">
+          <td class="code">
             
           <div class="highlight"><pre><span class="gp">$</span> go run timeouts.go 
 <span class="go">timeout 1</span>
 <span class="go">result 2</span>
 </pre></div>
 
-          </td>
-        </tr>
-        
-        <tr>
-          <td class="docs">
-            <p>Using this <code>select</code> timeout pattern requires
-communicating results over channels. This is a good
-idea in general because other important Go features are
-based on channels and <code>select</code>. We&rsquo;ll look at two
-examples of this next: timers and tickers.</p>
-
-          </td>
-          <td class="code empty">
-            
-          
           </td>
         </tr>
         
@@ -194,7 +179,7 @@ examples of this next: timers and tickers.</p>
     </div>
     <script>
       var codeLines = [];
-      codeLines.push('');codeLines.push('package main\u000A');codeLines.push('import \"time\"\u000Aimport \"fmt\"\u000A');codeLines.push('func main() {\u000A');codeLines.push('    c1 := make(chan string, 1)\u000A    go func() {\u000A        time.Sleep(2 * time.Second)\u000A        c1 \x3C- \"result 1\"\u000A    }()\u000A');codeLines.push('    select {\u000A    case res := \x3C-c1:\u000A        fmt.Println(res)\u000A    case \x3C-time.After(1 * time.Second):\u000A        fmt.Println(\"timeout 1\")\u000A    }\u000A');codeLines.push('    c2 := make(chan string, 1)\u000A    go func() {\u000A        time.Sleep(2 * time.Second)\u000A        c2 \x3C- \"result 2\"\u000A    }()\u000A    select {\u000A    case res := \x3C-c2:\u000A        fmt.Println(res)\u000A    case \x3C-time.After(3 * time.Second):\u000A        fmt.Println(\"timeout 2\")\u000A    }\u000A}\u000A');codeLines.push('');codeLines.push('');
+      codeLines.push('');codeLines.push('package main\u000A');codeLines.push('import \"time\"\u000Aimport \"fmt\"\u000A');codeLines.push('func main() {\u000A');codeLines.push('    c1 := make(chan string, 1)\u000A    go func() {\u000A        time.Sleep(2 * time.Second)\u000A        c1 \x3C- \"result 1\"\u000A    }()\u000A');codeLines.push('    select {\u000A    case res := \x3C-c1:\u000A        fmt.Println(res)\u000A    case \x3C-time.After(1 * time.Second):\u000A        fmt.Println(\"timeout 1\")\u000A    }\u000A');codeLines.push('    c2 := make(chan string, 1)\u000A    go func() {\u000A        time.Sleep(2 * time.Second)\u000A        c2 \x3C- \"result 2\"\u000A    }()\u000A    select {\u000A    case res := \x3C-c2:\u000A        fmt.Println(res)\u000A    case \x3C-time.After(3 * time.Second):\u000A        fmt.Println(\"timeout 2\")\u000A    }\u000A}\u000A');codeLines.push('');
     </script>
     <script src="site.js" async></script>
   </body>


### PR DESCRIPTION
The buffered channel prevents goroutine leaks in case the
channel doesn't end up being read (as indeed happens to c1).

Updates #207