### PR TITLE
Structs - fix example output

### DIFF
--- a/examples/structs/structs.sh
+++ b/examples/structs/structs.sh
@@ -3,7 +3,7 @@ $ go run structs.go
 {Alice 30}
 {Fred 0}
 &{Ann 40}
+&{Jon 42}
 Sean
 50
 51
-&{Jon 42}

--- a/public/structs
+++ b/public/structs
@@ -244,10 +244,10 @@ pointers are automatically dereferenced.</p>
 <span class="go">{Alice 30}</span>
 <span class="go">{Fred 0}</span>
 <span class="go">&amp;{Ann 40}</span>
+<span class="go">&amp;{Jon 42}</span>
 <span class="go">Sean</span>
 <span class="go">50</span>
 <span class="go">51</span>
-<span class="go">&amp;{Jon 42}</span>
 </pre></div>
 
           </td>


### PR DESCRIPTION
Quick fix to the ordering of the example output. It did not match the order that the code was printing in.