### PR TITLE
Structs: Fix output

### DIFF
--- a/examples/structs/structs.sh
+++ b/examples/structs/structs.sh
@@ -3,7 +3,7 @@ $ go run structs.go
 {Alice 30}
 {Fred 0}
 &{Ann 40}
+&{Jon 42}
 Sean
 50
 51
-&{Jon 42}


### PR DESCRIPTION
The output of structs.go was out of proper order.