### PR TITLE
Add clarification for else syntax

### DIFF
--- a/examples/if-else/if-else.go
+++ b/examples/if-else/if-else.go
@@ -29,6 +29,8 @@ func main() {
 	} else {
 		fmt.Println(num, "has multiple digits")
 	}
+	// else has to be in same line as closing parenthesis 
+	// Moving else to the next line would cause a syntax error
 }
 
 // Note that you don't need parentheses around conditions


### PR DESCRIPTION
Rationale: https://github.com/golang/go/issues/5440

else has to be in same line as closing parenthesis. Otherwise people coming from C/C++ would see not so obvious error. 

I've spent some time trying to debug basic fizz buzz code without knowing about it 