### PR TITLE
Fixed comment in tickers.go

### DIFF
--- a/examples/tickers/tickers.go
+++ b/examples/tickers/tickers.go
@@ -15,8 +15,8 @@ func main() {
 
 	// Tickers use a similar mechanism to timers: a
 	// channel that is sent values. Here we'll use the
-	// `range` builtin on the channel to iterate over
-	// the values as they arrive every 500ms.
+	// `select` builtin on the channel to await the
+	// values as they arrive every 500ms.
 	ticker := time.NewTicker(500 * time.Millisecond)
 	done := make(chan bool)
 


### PR DESCRIPTION
Comment says `range` builtin used but `select` is actually used.