### PR TITLE
Ukrainian Translation URL changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Contributor translations of the Go by Example site are available in:
 * [Japanese](http://spinute.org/go-by-example) by [spinute](https://github.com/spinute)
 * [Korean](https://mingrammer.com/gobyexample/) by [mingrammer](https://github.com/mingrammer)
 * [Spanish](http://goconejemplos.com) by the [Go Mexico community](https://github.com/dabit/gobyexample)
-* [Ukrainian](http://gobyexample.com.ua/) by [butuzov](https://github.com/butuzov/gobyexample)
+* [Ukrainian](http://butuzov.github.io/gobyexample/) by [butuzov](https://github.com/butuzov/gobyexample)
 
 ### Thanks
 


### PR DESCRIPTION
As gobyexample.com.ua going to be dropped soon,
translation moving to github pages hosting.