### PR TITLE
Remove magic numbers from code

### DIFF
--- a/examples/worker-pools/worker-pools.go
+++ b/examples/worker-pools/worker-pools.go
@@ -27,8 +27,9 @@ func main() {
 	// In order to use our pool of workers we need to send
 	// them work and collect their results. We make 2
 	// channels for this.
-	jobs := make(chan int, 100)
-	results := make(chan int, 100)
+	const numJobs = 5
+	jobs := make(chan int, numJobs)
+	results := make(chan int, numJobs)
 
 	// This starts up 3 workers, initially blocked
 	// because there are no jobs yet.
@@ -38,7 +39,7 @@ func main() {
 
 	// Here we send 5 `jobs` and then `close` that
 	// channel to indicate that's all the work we have.
-	for j := 1; j <= 5; j++ {
+	for j := 1; j <= numJobs; j++ {
 		jobs <- j
 	}
 	close(jobs)
@@ -47,7 +48,7 @@ func main() {
 	// This also ensures that the worker goroutines have
 	// finished. An alternative way to wait for multiple
 	// goroutines is to use a [WaitGroup](waitgroups).
-	for a := 1; a <= 5; a++ {
+	for a := 1; a <= numJobs; a++ {
 		<-results
 	}
 }

--- a/examples/worker-pools/worker-pools.hash
+++ b/examples/worker-pools/worker-pools.hash
@@ -1,2 +1,2 @@
-9b30cdfc3f46d634c3b8671a7ae1551c133fb6e2
-IiKZ-nj-nKY
+4ba08d5c7ee70dffe373b6a498082b53ae897cf6
+OqnamzFSR7y

--- a/public/worker-pools
+++ b/public/worker-pools
@@ -42,7 +42,7 @@ a <em>worker pool</em> using goroutines and channels.</p>
             
           </td>
           <td class="code leading">
-            <a href="http://play.golang.org/p/IiKZ-nj-nKY"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
+            <a href="http://play.golang.org/p/OqnamzFSR7y"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
           <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 
@@ -109,8 +109,9 @@ channels for this.</p>
           </td>
           <td class="code leading">
             
-          <div class="highlight"><pre>    <span class="nx">jobs</span> <span class="o">:=</span> <span class="nb">make</span><span class="p">(</span><span class="kd">chan</span> <span class="kt">int</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span>
-    <span class="nx">results</span> <span class="o">:=</span> <span class="nb">make</span><span class="p">(</span><span class="kd">chan</span> <span class="kt">int</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span>
+          <div class="highlight"><pre>    <span class="kd">const</span> <span class="nx">numJobs</span> <span class="p">=</span> <span class="mi">5</span>
+    <span class="nx">jobs</span> <span class="o">:=</span> <span class="nb">make</span><span class="p">(</span><span class="kd">chan</span> <span class="kt">int</span><span class="p">,</span> <span class="nx">numJobs</span><span class="p">)</span>
+    <span class="nx">results</span> <span class="o">:=</span> <span class="nb">make</span><span class="p">(</span><span class="kd">chan</span> <span class="kt">int</span><span class="p">,</span> <span class="nx">numJobs</span><span class="p">)</span>
 </pre></div>
 
           </td>
@@ -140,7 +141,7 @@ channel to indicate that&rsquo;s all the work we have.</p>
           </td>
           <td class="code leading">
             
-          <div class="highlight"><pre>    <span class="k">for</span> <span class="nx">j</span> <span class="o">:=</span> <span class="mi">1</span><span class="p">;</span> <span class="nx">j</span> <span class="o">&lt;=</span> <span class="mi">5</span><span class="p">;</span> <span class="nx">j</span><span class="o">++</span> <span class="p">{</span>
+          <div class="highlight"><pre>    <span class="k">for</span> <span class="nx">j</span> <span class="o">:=</span> <span class="mi">1</span><span class="p">;</span> <span class="nx">j</span> <span class="o">&lt;=</span> <span class="nx">numJobs</span><span class="p">;</span> <span class="nx">j</span><span class="o">++</span> <span class="p">{</span>
         <span class="nx">jobs</span> <span class="o">&lt;-</span> <span class="nx">j</span>
     <span class="p">}</span>
     <span class="nb">close</span><span class="p">(</span><span class="nx">jobs</span><span class="p">)</span>
@@ -159,7 +160,7 @@ goroutines is to use a <a href="waitgroups">WaitGroup</a>.</p>
           </td>
           <td class="code">
             
-          <div class="highlight"><pre>    <span class="k">for</span> <span class="nx">a</span> <span class="o">:=</span> <span class="mi">1</span><span class="p">;</span> <span class="nx">a</span> <span class="o">&lt;=</span> <span class="mi">5</span><span class="p">;</span> <span class="nx">a</span><span class="o">++</span> <span class="p">{</span>
+          <div class="highlight"><pre>    <span class="k">for</span> <span class="nx">a</span> <span class="o">:=</span> <span class="mi">1</span><span class="p">;</span> <span class="nx">a</span> <span class="o">&lt;=</span> <span class="nx">numJobs</span><span class="p">;</span> <span class="nx">a</span><span class="o">++</span> <span class="p">{</span>
         <span class="o">&lt;-</span><span class="nx">results</span>
     <span class="p">}</span>
 <span class="p">}</span>
@@ -223,7 +224,7 @@ there are 3 workers operating concurrently.</p>
     </div>
     <script>
       var codeLines = [];
-      codeLines.push('');codeLines.push('package main\u000A');codeLines.push('import (\u000A    \"fmt\"\u000A    \"time\"\u000A)\u000A');codeLines.push('func worker(id int, jobs \x3C-chan int, results chan\x3C- int) {\u000A    for j := range jobs {\u000A        fmt.Println(\"worker\", id, \"started  job\", j)\u000A        time.Sleep(time.Second)\u000A        fmt.Println(\"worker\", id, \"finished job\", j)\u000A        results \x3C- j * 2\u000A    }\u000A}\u000A');codeLines.push('func main() {\u000A');codeLines.push('    jobs := make(chan int, 100)\u000A    results := make(chan int, 100)\u000A');codeLines.push('    for w := 1; w \x3C= 3; w++ {\u000A        go worker(w, jobs, results)\u000A    }\u000A');codeLines.push('    for j := 1; j \x3C= 5; j++ {\u000A        jobs \x3C- j\u000A    }\u000A    close(jobs)\u000A');codeLines.push('    for a := 1; a \x3C= 5; a++ {\u000A        \x3C-results\u000A    }\u000A}\u000A');codeLines.push('');codeLines.push('');
+      codeLines.push('');codeLines.push('package main\u000A');codeLines.push('import (\u000A    \"fmt\"\u000A    \"time\"\u000A)\u000A');codeLines.push('func worker(id int, jobs \x3C-chan int, results chan\x3C- int) {\u000A    for j := range jobs {\u000A        fmt.Println(\"worker\", id, \"started  job\", j)\u000A        time.Sleep(time.Second)\u000A        fmt.Println(\"worker\", id, \"finished job\", j)\u000A        results \x3C- j * 2\u000A    }\u000A}\u000A');codeLines.push('func main() {\u000A');codeLines.push('    const numJobs = 5\u000A    jobs := make(chan int, numJobs)\u000A    results := make(chan int, numJobs)\u000A');codeLines.push('    for w := 1; w \x3C= 3; w++ {\u000A        go worker(w, jobs, results)\u000A    }\u000A');codeLines.push('    for j := 1; j \x3C= numJobs; j++ {\u000A        jobs \x3C- j\u000A    }\u000A    close(jobs)\u000A');codeLines.push('    for a := 1; a \x3C= numJobs; a++ {\u000A        \x3C-results\u000A    }\u000A}\u000A');codeLines.push('');codeLines.push('');
     </script>
     <script src="site.js" async></script>
   </body>


### PR DESCRIPTION
Removes some "magic numbers" from the example about worker pools.