### PR TITLE
Change chinese translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The Go Gopher is copyright [Renée French](http://reneefrench.blogspot.com/) and
 
 Contributor translations of the Go by Example site are available in:
 
-* [Chinese](https://gobyexample.xgwang.me/) by [xg-wang](https://github.com/xg-wang/gobyexample)
+* [Chinese](https://gobyexample-cn.github.io/) by [gobyexample-cn](https://github.com/gobyexample-cn)
 * [Czech](http://gobyexamples.sweb.cz/) by [martinkunc](https://github.com/martinkunc/gobyexample-cz)
 * [French](http://le-go-par-l-exemple.keiruaprod.fr) by [keirua](https://github.com/keirua/gobyexample)
 * [Italian](http://gobyexample.it) by the [Go Italian community](https://github.com/golangit/gobyexample-it)


### PR DESCRIPTION
Hello,

The previous maintainers of the `Chinese` documents can no longer maintain the documents in time due to work reasons. 

Now they will be transferred to [gobyexample-cn](https://github.com/gobyexample-cn) maintenance, and the previous maintainers ([xg-wang](https://github.com/xg-wang)) are also in the organization. 

Can you merge this pr, it is a great glory to us, thank you very much.