### PR TITLE
Fix typo in a comment of the context example

### DIFF
--- a/examples/context/context.go
+++ b/examples/context/context.go
@@ -21,7 +21,7 @@ func hello(w http.ResponseWriter, req *http.Request) {
 	fmt.Println("server: hello handler started")
 	defer fmt.Println("server: hello handler ended")
 
-	// Wait for 3 seconds before sending a reply to the
+	// Wait for a few seconds before sending a reply to the
 	// client. This could simulate some work the server is
 	// doing. While working, keep an eye on the context's
 	// `Done()` channel for a signal that we should cancel

--- a/examples/context/context.hash
+++ b/examples/context/context.hash
@@ -1,2 +1,2 @@
-e338acce5d0f64d6478be4b886bd24a0fd1a3afa
-Lun5aFco3pX
+a9537bfea55bca15d8db1c453e2d9852f9d447e1
+0_bu1o8rIBO

--- a/public/context
+++ b/public/context
@@ -36,7 +36,7 @@ across API boundaries and goroutines.</p>
 
           </td>
           <td class="code leading">
-            <a href="http://play.golang.org/p/Lun5aFco3pX"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
+            <a href="http://play.golang.org/p/0_bu1o8rIBO"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
           <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 
@@ -90,7 +90,7 @@ the <code>Context()</code> method.</p>
         
         <tr>
           <td class="docs">
-            <p>Wait for 3 seconds before sending a reply to the
+            <p>Wait for a few seconds before sending a reply to the
 client. This could simulate some work the server is
 doing. While working, keep an eye on the context&rsquo;s
 <code>Done()</code> channel for a signal that we should cancel


### PR DESCRIPTION
Fixes #317