### PR TITLE
NewPerson function should not be exported in structs examples. 

### DIFF
--- a/examples/structs/structs.go
+++ b/examples/structs/structs.go
@@ -12,8 +12,8 @@ type person struct {
 	age  int
 }
 
-// NewPerson constructs a new person struct with the given name
-func NewPerson(name string) *person {
+// newPerson constructs a new person struct with the given name
+func newPerson(name string) *person {
 	// You can safely return a pointer to local variable
 	// as a local variable will survive the scope of the function.
 	p := person{name: name}


### PR DESCRIPTION
fix: exported func NewPerson returns unexported type *store.person, which can be annoying to use