### PR TITLE
Clarify comment for the goroutines sample

### DIFF
--- a/examples/goroutines/goroutines.sh
+++ b/examples/goroutines/goroutines.sh
@@ -1,8 +1,8 @@
 # When we run this program, we see the output of the
 # blocking call first, then the output of the two
 # goroutines. The goroutines' output may be interleaved,
-# happens because goroutines are being run concurrently
-# by the Go runtime.
+# because goroutines are being run concurrently by the
+# Go runtime.
 $ go run goroutines.go
 direct : 0
 direct : 1

--- a/examples/goroutines/goroutines.sh
+++ b/examples/goroutines/goroutines.sh
@@ -1,7 +1,8 @@
 # When we run this program, we see the output of the
-# blocking call first, then the interleaved output of the
-# two goroutines. This interleaving reflects the
-# goroutines being run concurrently by the Go runtime.
+# blocking call first, then the output of the two
+# goroutines. The goroutines' output may be interleaved,
+# happens because goroutines are being run concurrently
+# by the Go runtime.
 $ go run goroutines.go
 direct : 0
 direct : 1

--- a/public/goroutines
+++ b/public/goroutines
@@ -159,8 +159,8 @@ separate goroutines now. Wait for them to finish
             <p>When we run this program, we see the output of the
 blocking call first, then the output of the two
 goroutines. The goroutines&rsquo; output may be interleaved,
-happens because goroutines are being run concurrently
-by the Go runtime.</p>
+because goroutines are being run concurrently by the
+Go runtime.</p>
 
           </td>
           <td class="code leading">

--- a/public/goroutines
+++ b/public/goroutines
@@ -157,9 +157,10 @@ separate goroutines now. Wait for them to finish
         <tr>
           <td class="docs">
             <p>When we run this program, we see the output of the
-blocking call first, then the interleaved output of the
-two goroutines. This interleaving reflects the
-goroutines being run concurrently by the Go runtime.</p>
+blocking call first, then the output of the two
+goroutines. The goroutines&rsquo; output may be interleaved,
+happens because goroutines are being run concurrently
+by the Go runtime.</p>
 
           </td>
           <td class="code leading">


### PR DESCRIPTION
Clarify comment for the goroutines sample
  
The current comment may be interpreted to say that the output must be
interleaved, when in fact it doesn't have to be (it depends on the order
the goroutines are run). Make the comment more permissive to avoid the
confusion.
    
Fixes #365
