### PR TITLE
Correction Method.go

### DIFF
--- a/examples/methods/methods.go
+++ b/examples/methods/methods.go
@@ -1,4 +1,4 @@
-// Go supports _methods_ defined on struct types.
+// Go supports _methods_ defined on any coustom defined types.
 
 package main
 


### PR DESCRIPTION
current doc incorrectly states that methods can only be defined on struct types