### PR TITLE
Fix a typo in the embedding example

### DIFF
--- a/public/embedding
+++ b/public/embedding
@@ -27,7 +27,7 @@
         
         <tr>
           <td class="docs">
-            <p>Go support <em>embedding</em> of structs and interfaces
+            <p>Go supports <em>embedding</em> of structs and interfaces
 to express a more seamless <em>composition</em> of types.</p>
 
           </td>


### PR DESCRIPTION
A small typo fix.

`Go support embedding` -> `Go supports embedding`