### PR TITLE
Update time-formatting-parsing.go

### DIFF
--- a/examples/time-formatting-parsing/time-formatting-parsing.go
+++ b/examples/time-formatting-parsing/time-formatting-parsing.go
@@ -18,7 +18,7 @@ func main() {
 	p(t.Format(time.RFC3339))
 
 	// Time parsing uses the same layout values as `Format`.
-	t1, e := time.Parse(
+	t1, _ := time.Parse(
 		time.RFC3339,
 		"2012-11-01T22:08:41+00:00")
 	p(t1)
@@ -34,7 +34,7 @@ func main() {
 	p(t.Format("Mon Jan _2 15:04:05 2006"))
 	p(t.Format("2006-01-02T15:04:05.999999-07:00"))
 	form := "3 04 PM"
-	t2, e := time.Parse(form, "8 41 PM")
+	t2, _ := time.Parse(form, "8 41 PM")
 	p(t2)
 
 	// For purely numeric representations you can also
@@ -47,6 +47,6 @@ func main() {
 	// `Parse` will return an error on malformed input
 	// explaining the parsing problem.
 	ansic := "Mon Jan _2 15:04:05 2006"
-	_, e = time.Parse(ansic, "8:41PM")
+	_, e := time.Parse(ansic, "8:41PM")
 	p(e)
 }


### PR DESCRIPTION
fixing undeclared name e at line 50 and removing unused e in 37 and 21