### PR TITLE
Examples: fix invalid html

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Not Found</title>

--- a/public/arrays
+++ b/public/arrays
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Arrays</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'switch';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'slices';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'switch';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'slices';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="arrays">
       <h2><a href="./">Go by Example</a>: Arrays</h2>

--- a/public/atomic-counters
+++ b/public/atomic-counters
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Atomic Counters</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'rate-limiting';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'mutexes';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'rate-limiting';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'mutexes';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="atomic-counters">
       <h2><a href="./">Go by Example</a>: Atomic Counters</h2>

--- a/public/base64-encoding
+++ b/public/base64-encoding
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Base64 Encoding</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'sha256-hashes';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'reading-files';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'sha256-hashes';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'reading-files';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="base64-encoding">
       <h2><a href="./">Go by Example</a>: Base64 Encoding</h2>

--- a/public/channel-buffering
+++ b/public/channel-buffering
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Channel Buffering</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'channels';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'channel-synchronization';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'channels';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'channel-synchronization';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="channel-buffering">
       <h2><a href="./">Go by Example</a>: Channel Buffering</h2>

--- a/public/channel-directions
+++ b/public/channel-directions
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Channel Directions</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'channel-synchronization';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'select';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'channel-synchronization';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'select';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="channel-directions">
       <h2><a href="./">Go by Example</a>: Channel Directions</h2>

--- a/public/channel-synchronization
+++ b/public/channel-synchronization
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Channel Synchronization</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'channel-buffering';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'channel-directions';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'channel-buffering';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'channel-directions';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="channel-synchronization">
       <h2><a href="./">Go by Example</a>: Channel Synchronization</h2>

--- a/public/channels
+++ b/public/channels
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Channels</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'goroutines';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'channel-buffering';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'goroutines';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'channel-buffering';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="channels">
       <h2><a href="./">Go by Example</a>: Channels</h2>

--- a/public/closing-channels
+++ b/public/closing-channels
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Closing Channels</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'non-blocking-channel-operations';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'range-over-channels';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'non-blocking-channel-operations';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'range-over-channels';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="closing-channels">
       <h2><a href="./">Go by Example</a>: Closing Channels</h2>

--- a/public/closures
+++ b/public/closures
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Closures</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'variadic-functions';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'recursion';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'variadic-functions';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'recursion';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="closures">
       <h2><a href="./">Go by Example</a>: Closures</h2>

--- a/public/command-line-arguments
+++ b/public/command-line-arguments
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Command-Line Arguments</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'testing-and-benchmarking';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'command-line-flags';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'testing-and-benchmarking';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'command-line-flags';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="command-line-arguments">
       <h2><a href="./">Go by Example</a>: Command-Line Arguments</h2>

--- a/public/command-line-flags
+++ b/public/command-line-flags
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Command-Line Flags</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'command-line-arguments';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'command-line-subcommands';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'command-line-arguments';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'command-line-subcommands';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="command-line-flags">
       <h2><a href="./">Go by Example</a>: Command-Line Flags</h2>

--- a/public/command-line-subcommands
+++ b/public/command-line-subcommands
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Command-Line Subcommands</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'command-line-flags';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'environment-variables';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'command-line-flags';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'environment-variables';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="command-line-subcommands">
       <h2><a href="./">Go by Example</a>: Command-Line Subcommands</h2>

--- a/public/constants
+++ b/public/constants
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Constants</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'variables';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'for';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'variables';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'for';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="constants">
       <h2><a href="./">Go by Example</a>: Constants</h2>

--- a/public/context
+++ b/public/context
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Context</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'http-servers';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'spawning-processes';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'http-servers';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'spawning-processes';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="context">
       <h2><a href="./">Go by Example</a>: Context</h2>

--- a/public/defer
+++ b/public/defer
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Defer</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'panic';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'recover';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'panic';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'recover';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="defer">
       <h2><a href="./">Go by Example</a>: Defer</h2>

--- a/public/directories
+++ b/public/directories
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Directories</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'file-paths';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'temporary-files-and-directories';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'file-paths';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'temporary-files-and-directories';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="directories">
       <h2><a href="./">Go by Example</a>: Directories</h2>

--- a/public/embed-directive
+++ b/public/embed-directive
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Embed Directive</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'temporary-files-and-directories';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'testing-and-benchmarking';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'temporary-files-and-directories';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'testing-and-benchmarking';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="embed-directive">
       <h2><a href="./">Go by Example</a>: Embed Directive</h2>

--- a/public/environment-variables
+++ b/public/environment-variables
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Environment Variables</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'command-line-subcommands';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'http-clients';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'command-line-subcommands';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'http-clients';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="environment-variables">
       <h2><a href="./">Go by Example</a>: Environment Variables</h2>

--- a/public/epoch
+++ b/public/epoch
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Epoch</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'time';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'time-formatting-parsing';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'time';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'time-formatting-parsing';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="epoch">
       <h2><a href="./">Go by Example</a>: Epoch</h2>

--- a/public/errors
+++ b/public/errors
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Errors</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'generics';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'goroutines';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'generics';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'goroutines';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="errors">
       <h2><a href="./">Go by Example</a>: Errors</h2>

--- a/public/execing-processes
+++ b/public/execing-processes
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Exec'ing Processes</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'spawning-processes';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'signals';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'spawning-processes';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'signals';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="execing-processes">
       <h2><a href="./">Go by Example</a>: Exec'ing Processes</h2>

--- a/public/exit
+++ b/public/exit
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Exit</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'signals';
+            }
+            
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'signals';
-          }
-          
-          
-      }
-  </script>
   <body>
     <div class="example" id="exit">
       <h2><a href="./">Go by Example</a>: Exit</h2>

--- a/public/file-paths
+++ b/public/file-paths
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: File Paths</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'line-filters';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'directories';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'line-filters';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'directories';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="file-paths">
       <h2><a href="./">Go by Example</a>: File Paths</h2>

--- a/public/for
+++ b/public/for
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: For</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'constants';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'if-else';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'constants';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'if-else';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="for">
       <h2><a href="./">Go by Example</a>: For</h2>

--- a/public/functions
+++ b/public/functions
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Functions</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'range';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'multiple-return-values';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'range';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'multiple-return-values';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="functions">
       <h2><a href="./">Go by Example</a>: Functions</h2>

--- a/public/generics
+++ b/public/generics
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Generics</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'struct-embedding';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'errors';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'struct-embedding';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'errors';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="generics">
       <h2><a href="./">Go by Example</a>: Generics</h2>

--- a/public/goroutines
+++ b/public/goroutines
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Goroutines</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'errors';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'channels';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'errors';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'channels';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="goroutines">
       <h2><a href="./">Go by Example</a>: Goroutines</h2>

--- a/public/hello-world
+++ b/public/hello-world
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Hello World</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'values';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'values';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="hello-world">
       <h2><a href="./">Go by Example</a>: Hello World</h2>

--- a/public/http-clients
+++ b/public/http-clients
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: HTTP Clients</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'environment-variables';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'http-servers';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'environment-variables';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'http-servers';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="http-clients">
       <h2><a href="./">Go by Example</a>: HTTP Clients</h2>

--- a/public/http-servers
+++ b/public/http-servers
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: HTTP Servers</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'http-clients';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'context';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'http-clients';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'context';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="http-servers">
       <h2><a href="./">Go by Example</a>: HTTP Servers</h2>

--- a/public/if-else
+++ b/public/if-else
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: If/Else</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'for';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'switch';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'for';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'switch';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="if-else">
       <h2><a href="./">Go by Example</a>: If/Else</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example</title>

--- a/public/interfaces
+++ b/public/interfaces
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Interfaces</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'methods';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'struct-embedding';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'methods';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'struct-embedding';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="interfaces">
       <h2><a href="./">Go by Example</a>: Interfaces</h2>

--- a/public/json
+++ b/public/json
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: JSON</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'regular-expressions';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'xml';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'regular-expressions';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'xml';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="json">
       <h2><a href="./">Go by Example</a>: JSON</h2>

--- a/public/line-filters
+++ b/public/line-filters
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Line Filters</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'writing-files';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'file-paths';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'writing-files';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'file-paths';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="line-filters">
       <h2><a href="./">Go by Example</a>: Line Filters</h2>

--- a/public/maps
+++ b/public/maps
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Maps</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'slices';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'range';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'slices';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'range';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="maps">
       <h2><a href="./">Go by Example</a>: Maps</h2>

--- a/public/methods
+++ b/public/methods
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Methods</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'structs';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'interfaces';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'structs';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'interfaces';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="methods">
       <h2><a href="./">Go by Example</a>: Methods</h2>

--- a/public/multiple-return-values
+++ b/public/multiple-return-values
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Multiple Return Values</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'functions';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'variadic-functions';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'functions';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'variadic-functions';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="multiple-return-values">
       <h2><a href="./">Go by Example</a>: Multiple Return Values</h2>

--- a/public/mutexes
+++ b/public/mutexes
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Mutexes</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'atomic-counters';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'stateful-goroutines';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'atomic-counters';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'stateful-goroutines';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="mutexes">
       <h2><a href="./">Go by Example</a>: Mutexes</h2>

--- a/public/non-blocking-channel-operations
+++ b/public/non-blocking-channel-operations
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Non-Blocking Channel Operations</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'timeouts';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'closing-channels';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'timeouts';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'closing-channels';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="non-blocking-channel-operations">
       <h2><a href="./">Go by Example</a>: Non-Blocking Channel Operations</h2>

--- a/public/number-parsing
+++ b/public/number-parsing
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Number Parsing</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'random-numbers';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'url-parsing';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'random-numbers';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'url-parsing';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="number-parsing">
       <h2><a href="./">Go by Example</a>: Number Parsing</h2>

--- a/public/panic
+++ b/public/panic
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Panic</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'sorting-by-functions';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'defer';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'sorting-by-functions';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'defer';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="panic">
       <h2><a href="./">Go by Example</a>: Panic</h2>

--- a/public/pointers
+++ b/public/pointers
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Pointers</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'recursion';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'strings-and-runes';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'recursion';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'strings-and-runes';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="pointers">
       <h2><a href="./">Go by Example</a>: Pointers</h2>

--- a/public/random-numbers
+++ b/public/random-numbers
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Random Numbers</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'time-formatting-parsing';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'number-parsing';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'time-formatting-parsing';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'number-parsing';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="random-numbers">
       <h2><a href="./">Go by Example</a>: Random Numbers</h2>

--- a/public/range
+++ b/public/range
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Range</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'maps';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'functions';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'maps';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'functions';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="range">
       <h2><a href="./">Go by Example</a>: Range</h2>

--- a/public/range-over-channels
+++ b/public/range-over-channels
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Range over Channels</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'closing-channels';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'timers';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'closing-channels';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'timers';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="range-over-channels">
       <h2><a href="./">Go by Example</a>: Range over Channels</h2>

--- a/public/rate-limiting
+++ b/public/rate-limiting
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Rate Limiting</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'waitgroups';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'atomic-counters';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'waitgroups';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'atomic-counters';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="rate-limiting">
       <h2><a href="./">Go by Example</a>: Rate Limiting</h2>

--- a/public/reading-files
+++ b/public/reading-files
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Reading Files</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'base64-encoding';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'writing-files';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'base64-encoding';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'writing-files';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="reading-files">
       <h2><a href="./">Go by Example</a>: Reading Files</h2>

--- a/public/recover
+++ b/public/recover
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Recover</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'defer';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'string-functions';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'defer';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'string-functions';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="recover">
       <h2><a href="./">Go by Example</a>: Recover</h2>

--- a/public/recursion
+++ b/public/recursion
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Recursion</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'closures';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'pointers';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'closures';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'pointers';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="recursion">
       <h2><a href="./">Go by Example</a>: Recursion</h2>

--- a/public/regular-expressions
+++ b/public/regular-expressions
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Regular Expressions</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'text-templates';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'json';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'text-templates';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'json';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="regular-expressions">
       <h2><a href="./">Go by Example</a>: Regular Expressions</h2>

--- a/public/select
+++ b/public/select
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Select</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'channel-directions';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'timeouts';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'channel-directions';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'timeouts';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="select">
       <h2><a href="./">Go by Example</a>: Select</h2>

--- a/public/sha256-hashes
+++ b/public/sha256-hashes
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: SHA256 Hashes</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'url-parsing';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'base64-encoding';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'url-parsing';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'base64-encoding';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="sha256-hashes">
       <h2><a href="./">Go by Example</a>: SHA256 Hashes</h2>

--- a/public/signals
+++ b/public/signals
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Signals</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'execing-processes';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'exit';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'execing-processes';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'exit';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="signals">
       <h2><a href="./">Go by Example</a>: Signals</h2>

--- a/public/slices
+++ b/public/slices
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Slices</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'arrays';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'maps';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'arrays';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'maps';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="slices">
       <h2><a href="./">Go by Example</a>: Slices</h2>

--- a/public/sorting
+++ b/public/sorting
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Sorting</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'stateful-goroutines';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'sorting-by-functions';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'stateful-goroutines';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'sorting-by-functions';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="sorting">
       <h2><a href="./">Go by Example</a>: Sorting</h2>

--- a/public/sorting-by-functions
+++ b/public/sorting-by-functions
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Sorting by Functions</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'sorting';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'panic';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'sorting';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'panic';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="sorting-by-functions">
       <h2><a href="./">Go by Example</a>: Sorting by Functions</h2>

--- a/public/spawning-processes
+++ b/public/spawning-processes
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Spawning Processes</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'context';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'execing-processes';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'context';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'execing-processes';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="spawning-processes">
       <h2><a href="./">Go by Example</a>: Spawning Processes</h2>

--- a/public/stateful-goroutines
+++ b/public/stateful-goroutines
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Stateful Goroutines</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'mutexes';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'sorting';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'mutexes';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'sorting';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="stateful-goroutines">
       <h2><a href="./">Go by Example</a>: Stateful Goroutines</h2>

--- a/public/string-formatting
+++ b/public/string-formatting
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: String Formatting</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'string-functions';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'text-templates';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'string-functions';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'text-templates';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="string-formatting">
       <h2><a href="./">Go by Example</a>: String Formatting</h2>

--- a/public/string-functions
+++ b/public/string-functions
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: String Functions</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'recover';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'string-formatting';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'recover';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'string-formatting';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="string-functions">
       <h2><a href="./">Go by Example</a>: String Functions</h2>

--- a/public/strings-and-runes
+++ b/public/strings-and-runes
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Strings and Runes</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'pointers';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'structs';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'pointers';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'structs';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="strings-and-runes">
       <h2><a href="./">Go by Example</a>: Strings and Runes</h2>

--- a/public/struct-embedding
+++ b/public/struct-embedding
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Struct Embedding</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'interfaces';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'generics';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'interfaces';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'generics';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="struct-embedding">
       <h2><a href="./">Go by Example</a>: Struct Embedding</h2>

--- a/public/structs
+++ b/public/structs
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Structs</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'strings-and-runes';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'methods';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'strings-and-runes';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'methods';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="structs">
       <h2><a href="./">Go by Example</a>: Structs</h2>

--- a/public/switch
+++ b/public/switch
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Switch</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'if-else';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'arrays';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'if-else';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'arrays';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="switch">
       <h2><a href="./">Go by Example</a>: Switch</h2>

--- a/public/temporary-files-and-directories
+++ b/public/temporary-files-and-directories
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Temporary Files and Directories</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'directories';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'embed-directive';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'directories';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'embed-directive';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="temporary-files-and-directories">
       <h2><a href="./">Go by Example</a>: Temporary Files and Directories</h2>

--- a/public/testing-and-benchmarking
+++ b/public/testing-and-benchmarking
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Testing and Benchmarking</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'embed-directive';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'command-line-arguments';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'embed-directive';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'command-line-arguments';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="testing-and-benchmarking">
       <h2><a href="./">Go by Example</a>: Testing and Benchmarking</h2>

--- a/public/text-templates
+++ b/public/text-templates
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Text Templates</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'string-formatting';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'regular-expressions';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'string-formatting';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'regular-expressions';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="text-templates">
       <h2><a href="./">Go by Example</a>: Text Templates</h2>

--- a/public/tickers
+++ b/public/tickers
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Tickers</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'timers';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'worker-pools';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'timers';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'worker-pools';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="tickers">
       <h2><a href="./">Go by Example</a>: Tickers</h2>

--- a/public/time
+++ b/public/time
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Time</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'xml';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'epoch';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'xml';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'epoch';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="time">
       <h2><a href="./">Go by Example</a>: Time</h2>

--- a/public/time-formatting-parsing
+++ b/public/time-formatting-parsing
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Time Formatting / Parsing</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'epoch';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'random-numbers';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'epoch';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'random-numbers';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="time-formatting-parsing">
       <h2><a href="./">Go by Example</a>: Time Formatting / Parsing</h2>

--- a/public/timeouts
+++ b/public/timeouts
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Timeouts</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'select';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'non-blocking-channel-operations';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'select';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'non-blocking-channel-operations';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="timeouts">
       <h2><a href="./">Go by Example</a>: Timeouts</h2>

--- a/public/timers
+++ b/public/timers
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Timers</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'range-over-channels';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'tickers';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'range-over-channels';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'tickers';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="timers">
       <h2><a href="./">Go by Example</a>: Timers</h2>

--- a/public/url-parsing
+++ b/public/url-parsing
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: URL Parsing</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'number-parsing';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'sha256-hashes';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'number-parsing';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'sha256-hashes';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="url-parsing">
       <h2><a href="./">Go by Example</a>: URL Parsing</h2>

--- a/public/values
+++ b/public/values
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Values</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'hello-world';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'variables';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'hello-world';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'variables';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="values">
       <h2><a href="./">Go by Example</a>: Values</h2>

--- a/public/variables
+++ b/public/variables
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Variables</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'values';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'constants';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'values';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'constants';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="variables">
       <h2><a href="./">Go by Example</a>: Variables</h2>

--- a/public/variadic-functions
+++ b/public/variadic-functions
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Variadic Functions</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'multiple-return-values';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'closures';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'multiple-return-values';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'closures';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="variadic-functions">
       <h2><a href="./">Go by Example</a>: Variadic Functions</h2>

--- a/public/waitgroups
+++ b/public/waitgroups
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: WaitGroups</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'worker-pools';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'rate-limiting';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'worker-pools';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'rate-limiting';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="waitgroups">
       <h2><a href="./">Go by Example</a>: WaitGroups</h2>

--- a/public/worker-pools
+++ b/public/worker-pools
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Worker Pools</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'tickers';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'waitgroups';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'tickers';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'waitgroups';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="worker-pools">
       <h2><a href="./">Go by Example</a>: Worker Pools</h2>

--- a/public/writing-files
+++ b/public/writing-files
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Writing Files</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'reading-files';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'line-filters';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'reading-files';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'line-filters';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="writing-files">
       <h2><a href="./">Go by Example</a>: Writing Files</h2>

--- a/public/xml
+++ b/public/xml
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: XML</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            
+            if (e.key == "ArrowLeft") {
+                window.location.href = 'json';
+            }
+            
+            
+            if (e.key == "ArrowRight") {
+                window.location.href = 'time';
+            }
+            
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          
-          if (e.key == "ArrowLeft") {
-              window.location.href = 'json';
-          }
-          
-          
-          if (e.key == "ArrowRight") {
-              window.location.href = 'time';
-          }
-          
-      }
-  </script>
   <body>
     <div class="example" id="xml">
       <h2><a href="./">Go by Example</a>: XML</h2>

--- a/templates/404.tmpl
+++ b/templates/404.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Not Found</title>

--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: {{.Name}}</title>
     <link rel=stylesheet href="site.css">
+    <script>
+        onkeydown = (e) => {
+            {{if .PrevExample}}
+            if (e.key == "ArrowLeft") {
+                window.location.href = '{{.PrevExample.ID}}';
+            }
+            {{end}}
+            {{if .NextExample}}
+            if (e.key == "ArrowRight") {
+                window.location.href = '{{.NextExample.ID}}';
+            }
+            {{end}}
+        }
+    </script>
   </head>
-  <script>
-      onkeydown = (e) => {
-          {{if .PrevExample}}
-          if (e.key == "ArrowLeft") {
-              window.location.href = '{{.PrevExample.ID}}';
-          }
-          {{end}}
-          {{if .NextExample}}
-          if (e.key == "ArrowRight") {
-              window.location.href = '{{.NextExample.ID}}';
-          }
-          {{end}}
-      }
-  </script>
   <body>
     <div class="example" id="{{.ID}}">
       <h2><a href="./">Go by Example</a>: {{.Name}}</h2>

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example</title>


### PR DESCRIPTION
The [W3C Validator service](https://validator.w3.org/) reveals that all examples of the gobyexample site contain invalid html:

See e.g. the [go routines example](https://validator.w3.org/nu/?showsource=yes&doc=https%3A%2F%2Fgobyexample.com%2Fgoroutines)

This PR fixes this. It also adds a `lang` attribute to the html tag, as advised by the validator.