### PR TITLE
Mention that environment variable set by program is also listed by `os.Environ()`

### DIFF
--- a/examples/environment-variables/environment-variables.sh
+++ b/examples/environment-variables/environment-variables.sh
@@ -11,6 +11,7 @@ TERM_PROGRAM
 PATH
 SHELL
 ...
+FOO
 
 # If we set `BAR` in the environment first, the running
 # program picks that value up.

--- a/public/environment-variables
+++ b/public/environment-variables
@@ -147,7 +147,8 @@ particular machine.</p>
 <span class="go">TERM_PROGRAM
 </span><span class="go">PATH
 </span><span class="go">SHELL
-</span><span class="go">...</span></pre>
+</span><span class="go">...
+</span><span class="go">FOO</span></pre>
           </td>
         </tr>
         


### PR DESCRIPTION
Otherwise readers may think that overridden variables are not listed. The Go documentation only implies this, so let's make it explicit for beginners.