### PR TITLE
Update generics.go

### DIFF
--- a/examples/generics/generics.go
+++ b/examples/generics/generics.go
@@ -14,7 +14,7 @@ import "fmt"
 // `V` has the `any` constraint, meaning that it's not
 // restricted in any way (`any` is an alias for `interface{}`).
 func MapKeys[K comparable, V any](m map[K]V) []K {
-	r := make([]K, 0, len(m))
+	var r []K
 	for k := range m {
 		r = append(r, k)
 	}


### PR DESCRIPTION
I just remove the make function from the MapKeys method, the new version looks cleaner.