### PR TITLE
Minor addition to if-else text on declarations

### DIFF
--- a/public/if-else
+++ b/public/if-else
@@ -105,7 +105,7 @@ straight-forward.</p>
         <tr>
           <td class="docs">
             <p>A statement can precede conditionals; any variables
-declared in this statement are available in all
+declared in this statement are available in the current and all the succeeding
 branches.</p>
 
           </td>


### PR DESCRIPTION
Extremely minor addition to if-else text on declarations preceding conditionals, by explicitly clarifying that variables declared are only available in branches succeeding the declaration, not all the branches in the if-else ladder (i.e. preceding branches will not have it in their scope)

This edit might be redundant since variables in Golang can only be used after declaration, but to a complete novice the original wording of `"...any variables declared in this statement are available in *all* branches..."` might be a little misleading and appear to say that the variable is in-scope for the preceding branches as well (as this seems to be a very Golang-specific semantic that other high-level languages like C/C++, Java, Scala, etc. don't support; and so it will be a brand new paradigm for developers coming from such languages).

Thanks!