### PR TITLE
Update range-over-channels.go

### DIFF
--- a/examples/range-over-channels/range-over-channels.go
+++ b/examples/range-over-channels/range-over-channels.go
@@ -13,6 +13,7 @@ func main() {
 	queue := make(chan string, 2)
 	queue <- "one"
 	queue <- "two"
+	// queue <- "three" // would deadlock, since the channel buffer is full
 	close(queue)
 
 	// This `range` iterates over each element as it's


### PR DESCRIPTION
Would have saved me a fair bit of time understanding channels, since the existing code doesn't make it obvious that `<-` is blocking to someone new to Go.