### PR TITLE
/bin/bash -> /usr/bin/env bash

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/build-loop
+++ b/tools/build-loop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TRAPPING=0
 trap "{ echo finishing; TRAPPING=1; }" SIGINT

--- a/tools/format
+++ b/tools/format
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/tools/generate
+++ b/tools/generate
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 exec go run tools/generate.go $@

--- a/tools/measure
+++ b/tools/measure
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 exec go run tools/measure.go

--- a/tools/serve
+++ b/tools/serve
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 exec go run tools/serve.go

--- a/tools/test
+++ b/tools/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Sanity testing of the examples.
 

--- a/tools/upload
+++ b/tools/upload
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 exec go run tools/upload.go -region us-east-1 -bucket gobyexample.com


### PR DESCRIPTION
Using env to find bash instead of hard coding bash path, [offers better portability](https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash).
By using env, the OS looks inside the PATH variable and finds bash, instead of trying to run bash from `/bin/bash` which is not the case for some GNU/Linux distros such as NixOS.