### PR TITLE
Small grammar correction

### DIFF
--- a/examples/slices/slices.go
+++ b/examples/slices/slices.go
@@ -20,7 +20,7 @@ func main() {
 	// By default a new slice's capacity is equal to its
 	// length; if we know the slice is going to grow ahead
 	// of time, it's possible to pass a capacity explicitly
-	// as an additional parameter ot `make`.
+	// as an additional parameter to `make`.
 	s = make([]string, 3)
 	fmt.Println("emp:", s, "len:", len(s), "cap:", cap(s))
 

--- a/public/slices
+++ b/public/slices
@@ -95,7 +95,7 @@ the builtin <code>make</code>. Here we make a slice of
 By default a new slice&rsquo;s capacity is equal to its
 length; if we know the slice is going to grow ahead
 of time, it&rsquo;s possible to pass a capacity explicitly
-as an additional parameter ot <code>make</code>.</p>
+as an additional parameter to <code>make</code>.</p>
 
           </td>
           <td class="code leading">


### PR DESCRIPTION
"it’s possible to pass a capacity explicitly as an additional parameter ot make"

"it’s possible to pass a capacity explicitly as an additional parameter **to** make"