### PR TITLE
typo fix - if-else.sh

### DIFF
--- a/examples/if-else/if-else.sh
+++ b/examples/if-else/if-else.sh
@@ -1,7 +1,7 @@
-$ go run if-else.go 
+$ go run if-else.go
 7 is odd
 8 is divisible by 4
-either 7 or 8 are even
+either 8 or 7 are even
 9 has 1 digit
 
 # There is no [ternary if](https://en.wikipedia.org/wiki/%3F:)

--- a/public/if-else
+++ b/public/if-else
@@ -151,10 +151,10 @@ in Go, but that the braces are required.</p>
           </td>
           <td class="code leading">
             
-          <pre class="chroma"><code><span class="line"><span class="cl"><span class="gp">$</span> go run if-else.go 
+          <pre class="chroma"><code><span class="line"><span class="cl"><span class="gp">$</span> go run if-else.go
 </span></span><span class="line"><span class="cl"><span class="go">7 is odd
 </span></span></span><span class="line"><span class="cl"><span class="go">8 is divisible by 4
-</span></span></span><span class="line"><span class="cl"><span class="go">either 7 or 8 are even
+</span></span></span><span class="line"><span class="cl"><span class="go">either 8 or 7 are even
 </span></span></span><span class="line"><span class="cl"><span class="go">9 has 1 digit</span></span></span></code></pre>
           </td>
         </tr>


### PR DESCRIPTION
Updated if-else.sh to match the code in the if-else example, here is the updated output:

![image](https://github.com/mmcgrana/gobyexample/assets/79242776/1cf0dc07-2b97-48cd-b081-026c0481df42)
