### PR TITLE
Fix verbiage for Strings and Runes (noissue)

### DIFF
--- a/examples/strings-and-runes/strings-and-runes.go
+++ b/examples/strings-and-runes/strings-and-runes.go
@@ -38,8 +38,9 @@ func main() {
 	// the `utf8` package. Note that the run-time of
 	// `RuneCountInString` depends on the size of the string,
 	// because it has to decode each UTF-8 rune sequentially.
-	// Some Thai characters are represented by multiple UTF-8
-	// code points, so the result of this count may be surprising.
+	// Some Thai characters are represented by UTF-8 code points
+	// that can span multiple bytes, so the result of this count
+	// may be surprising.
 	fmt.Println("Rune count:", utf8.RuneCountInString(s))
 
 	// A `range` loop handles strings specially and decodes

--- a/examples/strings-and-runes/strings-and-runes.hash
+++ b/examples/strings-and-runes/strings-and-runes.hash
@@ -1,2 +1,2 @@
-45a1127788eb4c0acfef48efee9ca386e06d4c58
-39BpTLf6BAz
+ffbc918567cea7cdadcaee87ffc404a1d4f5c62a
+-iNDXZ9IM3s

--- a/public/strings-and-runes
+++ b/public/strings-and-runes
@@ -48,7 +48,7 @@ introduction to the topic.</p>
             
           </td>
           <td class="code leading">
-            <a href="https://go.dev/play/p/39BpTLf6BAz"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
+            <a href="https://go.dev/play/p/-iNDXZ9IM3s"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
           <pre class="chroma"><code><span class="line"><span class="cl"><span class="kn">package</span> <span class="nx">main</span></span></span></code></pre>
           </td>
         </tr>
@@ -124,8 +124,9 @@ the bytes that constitute the code points in <code>s</code>.</p>
 the <code>utf8</code> package. Note that the run-time of
 <code>RuneCountInString</code> depends on the size of the string,
 because it has to decode each UTF-8 rune sequentially.
-Some Thai characters are represented by multiple UTF-8
-code points, so the result of this count may be surprising.</p>
+Some Thai characters are represented by UTF-8 code points
+that can span multiple bytes, so the result of this count
+may be surprising.</p>
 
           </td>
           <td class="code leading">


### PR DESCRIPTION
Found a minor inaccuracy in the write-up for the "Strings and Runes" section: a UTF-8 "code point" can span multiple bytes for a single Thai character; a single Thai character won't span multiple UTF-8 code points because a "UTF-8 code point" is defined as a specific point on the UTF-8 character map, pertaining to a singular, specific character.