### PR TITLE
use blank import for importing the embed package

### DIFF
--- a/examples/embed-directive/embed-directive.go
+++ b/examples/embed-directive/embed-directive.go
@@ -8,7 +8,7 @@ package main
 // Import the `embed` package; if you don't use any exported
 // identifiers from this package, you can do a blank import with `_ "embed"`.
 import (
-	"embed"
+	_ "embed"
 )
 
 // `embed` directives accept paths relative to the directory containing the


### PR DESCRIPTION
not using `_` fails compilation with an unused import error