### PR TITLE
Fixing waitgroups example

### DIFF
--- a/examples/waitgroups/waitgroups.go
+++ b/examples/waitgroups/waitgroups.go
@@ -34,10 +34,10 @@ func main() {
 		// the WaitGroup that this worker is done. This way the worker
 		// itself does not have to be aware of the concurrency primitives
 		// involved in its execution.
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 			worker(i)
-		}()
+		}(i)
 	}
 
 	// Block until the WaitGroup counter goes back to 0;


### PR DESCRIPTION
Fixing waitgroups example.

Instead of printing

```
Worker 6 starting
Worker 6 starting
Worker 6 starting
Worker 6 starting
Worker 6 starting
Worker 6 done
Worker 6 done
Worker 6 done
Worker 6 done
Worker 6 done
```

It should print something like

```
Worker 5 starting
Worker 2 starting
Worker 4 starting
Worker 1 starting
Worker 3 starting
Worker 3 done
Worker 4 done
Worker 5 done
Worker 2 done
Worker 1 done
```