### PR TITLE
Add the shell prompt/command to custom-errors.sh

### DIFF
--- a/examples/custom-errors/custom-errors.sh
+++ b/examples/custom-errors/custom-errors.sh
@@ -1,2 +1,3 @@
+$ go run custom-errors.sh
 42
 can't work with it

--- a/examples/errors/errors.sh
+++ b/examples/errors/errors.sh
@@ -1,3 +1,4 @@
+$ go run errors.sh
 f worked: 10
 f failed: can't work with 42
 Tea is ready!

--- a/public/custom-errors
+++ b/public/custom-errors
@@ -158,7 +158,8 @@ returns <code>false</code>.</p>
           </td>
           <td class="code">
             
-          <pre class="chroma"><code><span class="line"><span class="cl"><span class="go">42
+          <pre class="chroma"><code><span class="line"><span class="cl"><span class="gp">$</span> go run custom-errors.sh
+</span></span><span class="line"><span class="cl"><span class="go">42
 </span></span></span><span class="line"><span class="cl"><span class="go">can&#39;t work with it</span></span></span></code></pre>
           </td>
         </tr>

--- a/public/errors
+++ b/public/errors
@@ -237,7 +237,8 @@ errors in a chain of errors.</p>
           </td>
           <td class="code">
             
-          <pre class="chroma"><code><span class="line"><span class="cl"><span class="go">f worked: 10
+          <pre class="chroma"><code><span class="line"><span class="cl"><span class="gp">$</span> go run errors.sh
+</span></span><span class="line"><span class="cl"><span class="go">f worked: 10
 </span></span></span><span class="line"><span class="cl"><span class="go">f failed: can&#39;t work with 42
 </span></span></span><span class="line"><span class="cl"><span class="go">Tea is ready!
 </span></span></span><span class="line"><span class="cl"><span class="go">Tea is ready!


### PR DESCRIPTION
The shell entry for custom-errors is missing the shell prompt line. Small change, but nice for consistency!