### PR TITLE
Fix typo in a comment

### DIFF
--- a/examples/custom-errors/custom-errors.go
+++ b/examples/custom-errors/custom-errors.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// A custom error type usualy has the suffix "Error".
+// A custom error type usually has the suffix "Error".
 type argError struct {
 	arg     int
 	message string

--- a/examples/custom-errors/custom-errors.hash
+++ b/examples/custom-errors/custom-errors.hash
@@ -1,2 +1,2 @@
-9ee495d1322218925d6c654626398d7f3de0e208
-uhdXdp_OCct
+e63d61872edce05ea3ec797958eff48d1decfbd8
+qKKTjmc6SuB

--- a/public/custom-errors
+++ b/public/custom-errors
@@ -44,7 +44,7 @@ to explicitly represent an argument error.</p>
             
           </td>
           <td class="code leading">
-            <a href="https://go.dev/play/p/uhdXdp_OCct"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
+            <a href="https://go.dev/play/p/qKKTjmc6SuB"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
           <pre class="chroma"><code><span class="line"><span class="cl"><span class="kn">package</span> <span class="nx">main</span></span></span></code></pre>
           </td>
         </tr>
@@ -64,7 +64,7 @@ to explicitly represent an argument error.</p>
         
         <tr>
           <td class="docs">
-            <p>A custom error type usualy has the suffix &ldquo;Error&rdquo;.</p>
+            <p>A custom error type usually has the suffix &ldquo;Error&rdquo;.</p>
 
           </td>
           <td class="code leading">


### PR DESCRIPTION
`usualy` -> `usually`.

I ran `./tools/build` and some lines were moved.