### PR TITLE
[bugfix] Stop breaking browser navigation shortcuts

### DIFF
--- a/public/arrays
+++ b/public/arrays
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'switch';

--- a/public/atomic-counters
+++ b/public/atomic-counters
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'rate-limiting';

--- a/public/base64-encoding
+++ b/public/base64-encoding
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'sha256-hashes';

--- a/public/channel-buffering
+++ b/public/channel-buffering
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'channels';

--- a/public/channel-directions
+++ b/public/channel-directions
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'channel-synchronization';

--- a/public/channel-synchronization
+++ b/public/channel-synchronization
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'channel-buffering';

--- a/public/channels
+++ b/public/channels
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'goroutines';

--- a/public/closing-channels
+++ b/public/closing-channels
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'non-blocking-channel-operations';

--- a/public/closures
+++ b/public/closures
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'variadic-functions';

--- a/public/command-line-arguments
+++ b/public/command-line-arguments
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'testing-and-benchmarking';

--- a/public/command-line-flags
+++ b/public/command-line-flags
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'command-line-arguments';

--- a/public/command-line-subcommands
+++ b/public/command-line-subcommands
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'command-line-flags';

--- a/public/constants
+++ b/public/constants
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'variables';

--- a/public/context
+++ b/public/context
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'http-server';

--- a/public/custom-errors
+++ b/public/custom-errors
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'errors';

--- a/public/defer
+++ b/public/defer
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'panic';

--- a/public/directories
+++ b/public/directories
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'file-paths';

--- a/public/embed-directive
+++ b/public/embed-directive
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'temporary-files-and-directories';

--- a/public/environment-variables
+++ b/public/environment-variables
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'command-line-subcommands';

--- a/public/epoch
+++ b/public/epoch
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'time';

--- a/public/errors
+++ b/public/errors
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'generics';

--- a/public/execing-processes
+++ b/public/execing-processes
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'spawning-processes';

--- a/public/exit
+++ b/public/exit
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'signals';

--- a/public/file-paths
+++ b/public/file-paths
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'line-filters';

--- a/public/for
+++ b/public/for
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'constants';

--- a/public/functions
+++ b/public/functions
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'range';

--- a/public/generics
+++ b/public/generics
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'struct-embedding';

--- a/public/goroutines
+++ b/public/goroutines
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'custom-errors';

--- a/public/hello-world
+++ b/public/hello-world
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           
           if (e.key == "ArrowRight") {

--- a/public/http-client
+++ b/public/http-client
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'logging';

--- a/public/http-server
+++ b/public/http-server
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'http-client';

--- a/public/if-else
+++ b/public/if-else
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'for';

--- a/public/interfaces
+++ b/public/interfaces
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'methods';

--- a/public/json
+++ b/public/json
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'regular-expressions';

--- a/public/line-filters
+++ b/public/line-filters
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'writing-files';

--- a/public/logging
+++ b/public/logging
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'environment-variables';

--- a/public/maps
+++ b/public/maps
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'slices';

--- a/public/methods
+++ b/public/methods
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'structs';

--- a/public/multiple-return-values
+++ b/public/multiple-return-values
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'functions';

--- a/public/mutexes
+++ b/public/mutexes
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'atomic-counters';

--- a/public/non-blocking-channel-operations
+++ b/public/non-blocking-channel-operations
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'timeouts';

--- a/public/number-parsing
+++ b/public/number-parsing
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'random-numbers';

--- a/public/panic
+++ b/public/panic
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'sorting-by-functions';

--- a/public/pointers
+++ b/public/pointers
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'recursion';

--- a/public/random-numbers
+++ b/public/random-numbers
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'time-formatting-parsing';

--- a/public/range
+++ b/public/range
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'maps';

--- a/public/range-over-channels
+++ b/public/range-over-channels
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'closing-channels';

--- a/public/rate-limiting
+++ b/public/rate-limiting
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'waitgroups';

--- a/public/reading-files
+++ b/public/reading-files
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'base64-encoding';

--- a/public/recover
+++ b/public/recover
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'defer';

--- a/public/recursion
+++ b/public/recursion
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'closures';

--- a/public/regular-expressions
+++ b/public/regular-expressions
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'text-templates';

--- a/public/select
+++ b/public/select
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'channel-directions';

--- a/public/sha256-hashes
+++ b/public/sha256-hashes
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'url-parsing';

--- a/public/signals
+++ b/public/signals
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'execing-processes';

--- a/public/slices
+++ b/public/slices
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'arrays';

--- a/public/sorting
+++ b/public/sorting
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'stateful-goroutines';

--- a/public/sorting-by-functions
+++ b/public/sorting-by-functions
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'sorting';

--- a/public/spawning-processes
+++ b/public/spawning-processes
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'context';

--- a/public/stateful-goroutines
+++ b/public/stateful-goroutines
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'mutexes';

--- a/public/string-formatting
+++ b/public/string-formatting
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'string-functions';

--- a/public/string-functions
+++ b/public/string-functions
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'recover';

--- a/public/strings-and-runes
+++ b/public/strings-and-runes
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'pointers';

--- a/public/struct-embedding
+++ b/public/struct-embedding
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'interfaces';

--- a/public/structs
+++ b/public/structs
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'strings-and-runes';

--- a/public/switch
+++ b/public/switch
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'if-else';

--- a/public/temporary-files-and-directories
+++ b/public/temporary-files-and-directories
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'directories';

--- a/public/testing-and-benchmarking
+++ b/public/testing-and-benchmarking
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'embed-directive';

--- a/public/text-templates
+++ b/public/text-templates
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'string-formatting';

--- a/public/tickers
+++ b/public/tickers
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'timers';

--- a/public/time
+++ b/public/time
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'xml';

--- a/public/time-formatting-parsing
+++ b/public/time-formatting-parsing
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'epoch';

--- a/public/timeouts
+++ b/public/timeouts
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'select';

--- a/public/timers
+++ b/public/timers
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'range-over-channels';

--- a/public/url-parsing
+++ b/public/url-parsing
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'number-parsing';

--- a/public/values
+++ b/public/values
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'hello-world';

--- a/public/variables
+++ b/public/variables
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'values';

--- a/public/variadic-functions
+++ b/public/variadic-functions
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'multiple-return-values';

--- a/public/waitgroups
+++ b/public/waitgroups
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'worker-pools';

--- a/public/worker-pools
+++ b/public/worker-pools
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'tickers';

--- a/public/writing-files
+++ b/public/writing-files
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'reading-files';

--- a/public/xml
+++ b/public/xml
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           
           if (e.key == "ArrowLeft") {
               window.location.href = 'json';

--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -7,6 +7,9 @@
   </head>
   <script>
       onkeydown = (e) => {
+          if (e.ctrlKey || e.altKey || e.shiftKey) {
+              return;
+          }
           {{if .PrevExample}}
           if (e.key == "ArrowLeft") {
               window.location.href = '{{.PrevExample.ID}}';


### PR DESCRIPTION
On Linux Chrome I use ALT + Arrows to go back in the browser, but instead it paginates between examples.

Fixed it by checking for special key modifiers and do nothing (to the let the browser handle it). 
I think the user always intends a system shortcut if they use a modifier key.