### PR TITLE
Fix typo in the enums example

### DIFF
--- a/examples/enums/enums.go
+++ b/examples/enums/enums.go
@@ -24,7 +24,7 @@ const (
 )
 
 // By implementing the [fmt.Stringer](https://pkg.go.dev/fmt#Stringer)
-// interface, values of `StateType` can be printed out or converted
+// interface, values of `ServerState` can be printed out or converted
 // to strings.
 //
 // This can get cumbersome if there are many possible values. In such

--- a/examples/enums/enums.hash
+++ b/examples/enums/enums.hash
@@ -1,2 +1,2 @@
-1c5bf51fa651a25eb6d9d2d24cf7dbd2713aca0c
--6dSwyy83xj
+b93a8b040a9c2d0de4050689f6eaab2ff0aa4644
+NyVXnLsm3cu

--- a/public/enums
+++ b/public/enums
@@ -49,7 +49,7 @@ are simple to implement using existing language idioms.</p>
             
           </td>
           <td class="code leading">
-            <a href="https://go.dev/play/p/-6dSwyy83xj"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
+            <a href="https://go.dev/play/p/NyVXnLsm3cu"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
           <pre class="chroma"><code><span class="line"><span class="cl"><span class="kn">package</span> <span class="nx">main</span></span></span></code></pre>
           </td>
         </tr>
@@ -97,7 +97,7 @@ case 0, 1, 2 and so on.</p>
         <tr>
           <td class="docs">
             <p>By implementing the <a href="https://pkg.go.dev/fmt#Stringer">fmt.Stringer</a>
-interface, values of <code>StateType</code> can be printed out or converted
+interface, values of <code>ServerState</code> can be printed out or converted
 to strings.</p>
 
 <p>This can get cumbersome if there are many possible values. In such


### PR DESCRIPTION
Should be `ServerState` instead of `StateType` on [Enums](https://gobyexample.com/enums)
