### PR TITLE
Hhange stderr to stdout in logging.go

### DIFF
--- a/examples/logging/logging.go
+++ b/examples/logging/logging.go
@@ -66,7 +66,7 @@ func main() {
 	// The `slog` package provides
 	// _structured_ log output. For example, logging
 	// in JSON format is straightforward.
-	jsonHandler := slog.NewJSONHandler(os.Stderr, nil)
+	jsonHandler := slog.NewJSONHandler(os.Stdout, nil)
 	myslog := slog.New(jsonHandler)
 	myslog.Info("hi there")
 


### PR DESCRIPTION
what would be the reason to put the logs to standard error as opposed to stdout ?