### PR TITLE
Shorten interface explanation

### DIFF
--- a/examples/struct-embedding/struct-embedding.go
+++ b/examples/struct-embedding/struct-embedding.go
@@ -53,10 +53,11 @@ func main() {
 		describe() string
 	}
 
-	// Embedding structs with methods may be used to bestow
-	// interface implementations onto other structs. Here
-	// we see that a `container` now implements the
-	// `describer` interface because it embeds `base`.
-	var d describer = co
-	fmt.Println("describer:", d.describe())
+	// Embedding a struct that implements an interface
+	// lets us use the parent struct anywhere we can
+	// use the interface.
+	f := func(d describer) {
+		fmt.Println("describer:", d.describe())
+	}
+	f(co)
 }

--- a/examples/struct-embedding/struct-embedding.hash
+++ b/examples/struct-embedding/struct-embedding.hash
@@ -1,2 +1,2 @@
-7ac6d1889bfc68e8f3f931014c87e05db2ecda95
--LOu1L0i2tR
+fb6fe5d38bd225c5a651c85c56c69b8c029e2eef
+cGeMoxZrs8o

--- a/public/struct-embedding
+++ b/public/struct-embedding
@@ -48,7 +48,7 @@ files and folders into the application binary.</p>
             
           </td>
           <td class="code leading">
-            <a href="https://go.dev/play/p/-LOu1L0i2tR"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
+            <a href="https://go.dev/play/p/cGeMoxZrs8o"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
           <pre class="chroma"><code><span class="line"><span class="cl"><span class="kn">package</span> <span class="nx">main</span></span></span></code></pre>
           </td>
         </tr>
@@ -182,16 +182,17 @@ directly on <code>co</code>.</p>
         
         <tr>
           <td class="docs">
-            <p>Embedding structs with methods may be used to bestow
-interface implementations onto other structs. Here
-we see that a <code>container</code> now implements the
-<code>describer</code> interface because it embeds <code>base</code>.</p>
+            <p>Embedding a struct that implements an interface
+lets us use the parent struct anywhere we can
+use the interface.</p>
 
           </td>
           <td class="code">
             
-          <pre class="chroma"><code><span class="line"><span class="cl">    <span class="kd">var</span> <span class="nx">d</span> <span class="nx">describer</span> <span class="p">=</span> <span class="nx">co</span>
-</span></span><span class="line"><span class="cl">    <span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;describer:&#34;</span><span class="p">,</span> <span class="nx">d</span><span class="p">.</span><span class="nf">describe</span><span class="p">())</span>
+          <pre class="chroma"><code><span class="line"><span class="cl">    <span class="nx">f</span> <span class="o">:=</span> <span class="kd">func</span><span class="p">(</span><span class="nx">d</span> <span class="nx">describer</span><span class="p">)</span> <span class="p">{</span>
+</span></span><span class="line"><span class="cl">        <span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;describer:&#34;</span><span class="p">,</span> <span class="nx">d</span><span class="p">.</span><span class="nf">describe</span><span class="p">())</span>
+</span></span><span class="line"><span class="cl">    <span class="p">}</span>
+</span></span><span class="line"><span class="cl">    <span class="nf">f</span><span class="p">(</span><span class="nx">co</span><span class="p">)</span>
 </span></span><span class="line"><span class="cl"><span class="p">}</span></span></span></code></pre>
           </td>
         </tr>
@@ -229,7 +230,7 @@ we see that a <code>container</code> now implements the
     </div>
     <script>
       var codeLines = [];
-      codeLines.push('');codeLines.push('package main\u000A');codeLines.push('import \"fmt\"\u000A');codeLines.push('type base struct {\u000A    num int\u000A}\u000A');codeLines.push('func (b base) describe() string {\u000A    return fmt.Sprintf(\"base with num\u003D%v\", b.num)\u000A}\u000A');codeLines.push('type container struct {\u000A    base\u000A    str string\u000A}\u000A');codeLines.push('func main() {\u000A');codeLines.push('    co :\u003D container{\u000A        base: base{\u000A            num: 1,\u000A        },\u000A        str: \"some name\",\u000A    }\u000A');codeLines.push('    fmt.Printf(\"co\u003D{num: %v, str: %v}\\n\", co.num, co.str)\u000A');codeLines.push('    fmt.Println(\"also num:\", co.base.num)\u000A');codeLines.push('    fmt.Println(\"describe:\", co.describe())\u000A');codeLines.push('    type describer interface {\u000A        describe() string\u000A    }\u000A');codeLines.push('    var d describer \u003D co\u000A    fmt.Println(\"describer:\", d.describe())\u000A}\u000A');codeLines.push('');
+      codeLines.push('');codeLines.push('package main\u000A');codeLines.push('import \"fmt\"\u000A');codeLines.push('type base struct {\u000A    num int\u000A}\u000A');codeLines.push('func (b base) describe() string {\u000A    return fmt.Sprintf(\"base with num\u003D%v\", b.num)\u000A}\u000A');codeLines.push('type container struct {\u000A    base\u000A    str string\u000A}\u000A');codeLines.push('func main() {\u000A');codeLines.push('    co :\u003D container{\u000A        base: base{\u000A            num: 1,\u000A        },\u000A        str: \"some name\",\u000A    }\u000A');codeLines.push('    fmt.Printf(\"co\u003D{num: %v, str: %v}\\n\", co.num, co.str)\u000A');codeLines.push('    fmt.Println(\"also num:\", co.base.num)\u000A');codeLines.push('    fmt.Println(\"describe:\", co.describe())\u000A');codeLines.push('    type describer interface {\u000A        describe() string\u000A    }\u000A');codeLines.push('    f :\u003D func(d describer) {\u000A        fmt.Println(\"describer:\", d.describe())\u000A    }\u000A    f(co)\u000A}\u000A');codeLines.push('');
     </script>
     <script src="site.js" async></script>
   </body>


### PR DESCRIPTION
The explanation for embedding a struct which implements an interface is confusing.
The code for it restricts the `container` variable to one method: `describe`.

The example code in this patch uses the `describer` interface to specify a contract between a function and it's caller.
This explicitly gives a practical reason for using struct embedding or adding a method to an already embedded struct.