### PR TITLE
Update closing-channels.sh

### DIFF
--- a/examples/closing-channels/closing-channels.sh
+++ b/examples/closing-channels/closing-channels.sh
@@ -1,11 +1,11 @@
 $ go run closing-channels.go 
 sent job 1
-received job 1
 sent job 2
-received job 2
 sent job 3
-received job 3
 sent all jobs
+received job 1
+received job 2
+received job 3
 received all jobs
 received more jobs: false
 


### PR DESCRIPTION
Updated results on running the code in go
go version go1.22.0 linux/amd64

Explanation:
Since jobs being a buffered channel of capacity 5, when we are sending values 1 to 3 to job channel on line 22 to 25.
The send to job channel on line 23 is non blocking.
Hence Sent job takes place immediately, while anonymous go routine on line 9 gets scheduled and executed in background after some delay, and it is during that time when receiving from job channel takes place.
Also to mention receiving is also non-blocking.
Functioning of done channel works the same as illustrated in the example.