### PR TITLE
Updated Closure instruction

### DIFF
--- a/examples/closures/closures.go
+++ b/examples/closures/closures.go
@@ -7,10 +7,10 @@ package main
 
 import "fmt"
 
-// This function `intSeq` returns another function, which
-// we define anonymously in the body of `intSeq`. The
-// returned function _closes over_ the variable `i` to
-// form a closure.
+// This function `intSeq` returns another function with
+// equal return type(s), which we define anonymously in
+// the body of `intSeq`. The returned function
+// _closes over_ the variable `i` to form a closure.
 func intSeq() func() int {
 	i := 0
 	return func() int {


### PR DESCRIPTION
Added explanation that one has to align return types. It wasn't clear to me that not only a function but also the return types of that very function have to be specified. It is clear when you know it. But as a Go beginner you could stumble over it, expecially when you start using multiple return types e.g. `(int, error)`