### PR TITLE
Fixed missing command in the range-over-iterators file

### DIFF
--- a/examples/range-over-iterators/range-over-iterators.sh
+++ b/examples/range-over-iterators/range-over-iterators.sh
@@ -1,3 +1,4 @@
+$ go run range-over-iterators.go
 10
 13
 23

--- a/public/range-over-iterators
+++ b/public/range-over-iterators
@@ -260,7 +260,8 @@ passed to the iterator will return <code>false</code>.</p>
           </td>
           <td class="code">
             
-          <pre class="chroma"><code><span class="line"><span class="cl"><span class="go">10
+          <pre class="chroma"><code><span class="line"><span class="cl"><span class="gp">$</span> go run range-over-iterators.go
+</span></span><span class="line"><span class="cl"><span class="go">10
 </span></span></span><span class="line"><span class="cl"><span class="go">13
 </span></span></span><span class="line"><span class="cl"><span class="go">23
 </span></span></span><span class="line"><span class="cl"><span class="go">all: [10 13 23]


### PR DESCRIPTION
The `range-over-iterators` file does not include the command `go run range-over-iterators.go`, which is inconsistent with the rest of the project. This omission may confuse users, as they won’t know what to name their file or which command to run locally. I have fixed this.