### PR TITLE
Fix http-server filename

### DIFF
--- a/examples/http-server/http-server.sh
+++ b/examples/http-server/http-server.sh
@@ -1,5 +1,5 @@
 # Run the server in the background.
-$ go run http-servers.go &
+$ go run http-server.go &
 
 # Access the `/hello` route.
 $ curl localhost:8090/hello

--- a/public/http-server
+++ b/public/http-server
@@ -162,7 +162,7 @@ router we&rsquo;ve just set up.</p>
           </td>
           <td class="code leading">
             
-          <pre class="chroma"><code><span class="line"><span class="cl"><span class="gp">$</span> go run http-servers.go &amp;</span></span></code></pre>
+          <pre class="chroma"><code><span class="line"><span class="cl"><span class="gp">$</span> go run http-server.go &amp;</span></span></code></pre>
           </td>
         </tr>
         


### PR DESCRIPTION
Fixed the non-existent filename used in the `http-server` example.