### PR TITLE
fix comment for closing channel

### DIFF
--- a/examples/closing-channels/closing-channels.go
+++ b/examples/closing-channels/closing-channels.go
@@ -17,7 +17,7 @@ func main() {
 	// Here's the worker goroutine. It repeatedly receives
 	// from `jobs` with `j, more := <-jobs`. In this
 	// special 2-value form of receive, the `more` value
-	// will be `false` if `jobs` has been `close`d and all
+	// will be `false` if all
 	// values in the channel have already been received.
 	// We use this to notify on `done` when we've worked
 	// all our jobs.
@@ -49,12 +49,12 @@ func main() {
 	<-done
 
 	// Reading from a closed channel succeeds immediately,
-	// returning the zero value of the underlying type.
+	// returning the zero value of the underlying type if
+	// the channel is empty or first unread buffered value.
 	// The optional second return value is `true` if the
 	// value received was delivered by a successful send
 	// operation to the channel, or `false` if it was a
-	// zero value generated because the channel is closed
-	// and empty.
+	// zero value generated because the channel is empty.
 	_, ok := <-jobs
 	fmt.Println("received more jobs:", ok)
 }


### PR DESCRIPTION
`j, more := <-jobs`, if channel `jobs` is closed, j is not always zero value, and `more` is also not always false.

Following are the test example.

package main

import (
	"fmt"
	"time"
)

func main() {
    jobs := make(chan int, 5)
    done := make(chan bool)

    go func() {
		time.Sleep(time.Minute)
        for j := 1; j <= 2; j++ {
            j, more := <-jobs
            if more {
                fmt.Println("received job", j)
            } else {
                fmt.Println("received all jobs")
            }
        }
		done <- true
    }()

    for j := 1; j <= 3; j++ {
        jobs <- j
        fmt.Println("sent job", j)
    }
    close(jobs)
    fmt.Println("sent all jobs")

    <-done

    t, ok := <-jobs
    fmt.Println("received more jobs:", t, ok)

	t, ok = <-jobs
    fmt.Println("received more jobs:", t, ok)	
}


[lixiaolian@YBBJ-1100637deMacBook-Pro example]$go run valus.go
sent job 1
sent job 2
sent job 3
sent all jobs
received job 1
received job 2
received more jobs: 3 true
received more jobs: 0 false