### PR TITLE
Add html-extension to output files

### DIFF
--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -12,12 +12,12 @@
           }
           {{if .PrevExample}}
           if (e.key == "ArrowLeft") {
-              window.location.href = '{{.PrevExample.ID}}';
+              window.location.href = '{{.PrevExample.FileName}}';
           }
           {{end}}
           {{if .NextExample}}
           if (e.key == "ArrowRight") {
-              window.location.href = '{{.NextExample.ID}}';
+              window.location.href = '{{.NextExample.FileName}}';
           }
           {{end}}
       }
@@ -42,7 +42,7 @@
       {{end}}
       {{if .NextExample}}
       <p class="next">
-        Next example: <a href="{{.NextExample.ID}}" rel="next">{{.NextExample.Name}}</a>.
+        Next example: <a href="{{.NextExample.FileName}}" rel="next">{{.NextExample.Name}}</a>.
       </p>
       {{end}}
 {{ template "footer" }}

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -33,7 +33,7 @@
 
       <ul>
       {{range .}}
-        <li><a href="{{.ID}}">{{.Name}}</a></li>
+        <li><a href="{{.FileName}}">{{.Name}}</a></li>
       {{end}}
       </ul>
 {{ template "footer" }}


### PR DESCRIPTION
For static sites (I'm using GitHub Pages) useful to generate output files with HTML-extensions. I added "-html" flat to generate.go

Without it generations works without any changes. With -html flag, output files generated with "html" extension.