### PR TITLE
fix: order of generics

### DIFF
--- a/examples/generics/generics.go
+++ b/examples/generics/generics.go
@@ -14,7 +14,7 @@ import "fmt"
 // of this type signature, see [this blog post](https://go.dev/blog/deconstructing-type-parameters).
 // Note that this function exists in the standard library
 // as [slices.Index](https://pkg.go.dev/slices#Index).
-func SlicesIndex[S ~[]E, E comparable](s S, v E) int {
+func SlicesIndex[E comparable, S ~[]E](s S, v E) int {
 	for i := range s {
 		if v == s[i] {
 			return i


### PR DESCRIPTION
Fix type parameter order in SlicesIndex for clarity

Reordered type parameters so that E is defined before S (~[]E), making the dependency clear. The previous order (S before E) was confusing for beginners, as S depends on E being defined. This improves readability and aligns with best practices in Go generics.