### PR TITLE
Replace the raster images by embeded svg, to fit the site color

### DIFF
--- a/templates/404.tmpl
+++ b/templates/404.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: Not Found</title>

--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example: {{.Name}}</title>
@@ -33,7 +33,10 @@
             {{.DocsRendered}}
           </td>
           <td class="code{{if .CodeEmpty}} empty{{end}}{{if .CodeLeading}} leading{{end}}">
-            {{if .CodeRun}}<a href="https://go.dev/play/p/{{$.URLHash}}"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />{{end}}
+            {{if .CodeRun}}
+              <a href="https://go.dev/play/p/{{$.URLHash}}" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="run"><polygon points="6 3 20 12 6 21 6 3"/></svg></a>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="copy"><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/></svg>
+            {{end}}
           {{.CodeRendered}}
           </td>
         </tr>

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Go by Example</title>

--- a/templates/site.css
+++ b/templates/site.css
@@ -126,15 +126,15 @@ pre, code {
   font-size: 14px; line-height: 18px;
   font-family: 'Menlo', 'Monaco', 'Consolas', 'Lucida Console', monospace;
 }
-img.copy, img.run {
+svg.copy, svg.run {
   height: 16px;
   width: 16px;
   float: right
 }
-img.copy, img.run {
+svg.copy, svg.run {
   cursor: pointer;
 }
-img.copy {
+svg.copy {
   margin-right: 4px;
 }
 


### PR DESCRIPTION
Just a simple improvement of site UI.

While the performance impact is minimal, this change improves visual clarity and ensures better adaptability across light and dark themes, enhancing the overall readability and user experience of the site.

![Screenshot 2025-05-11 at 00 42 59](https://github.com/user-attachments/assets/33a88636-a53a-4ce9-a6da-f23b45c2a40f)
![Screenshot 2025-05-11 at 00 42 31](https://github.com/user-attachments/assets/912fad8a-9adf-4ed1-b3ef-99c972431046)
