### PR TITLE
Fix incorrect comment style in timers.sh

### DIFF
--- a/examples/timers/timers.sh
+++ b/examples/timers/timers.sh
@@ -1,6 +1,6 @@
-// The first timer will fire ~2s after we start the
-// program, but the second should be stopped before it has
-// a chance to fire.
+# The first timer will fire ~2s after we start the
+# program, but the second should be stopped before it has
+# a chance to fire.
 $ go run timers.go
 Timer 1 fired
 Timer 2 stopped


### PR DESCRIPTION
Replaced Go-style `//` comments with shell-style `#` comments in `examples/timers/timers.sh`. Resolves issue #604 