### PR TITLE
Fix hardcoded /tmp paths for cross-platform compatibility using osTempDir

### DIFF
--- a/examples/defer/defer.go
+++ b/examples/defer/defer.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // Suppose we wanted to create a file, write to it,
@@ -20,7 +21,7 @@ func main() {
 	// with `closeFile`. This will be executed at the end
 	// of the enclosing function (`main`), after
 	// `writeFile` has finished.
-	f := createFile("/tmp/defer.txt")
+	f := createFile(filepath.Join(os.TempDir(), "defer.txt"))
 	defer closeFile(f)
 	writeFile(f)
 }

--- a/examples/panic/panic.go
+++ b/examples/panic/panic.go
@@ -5,7 +5,10 @@
 
 package main
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 func main() {
 
@@ -14,11 +17,14 @@ func main() {
 	// site designed to panic.
 	panic("a problem")
 
+	// Note: The following code is unreachable because of the
+    // panic above, but it demonstrates panicking on unexpected
+    // errors when creating a file.
 	// A common use of panic is to abort if a function
 	// returns an error value that we don't know how to
 	// (or want to) handle. Here's an example of
 	// `panic`king if we get an unexpected error when creating a new file.
-	_, err := os.Create("/tmp/file")
+	_, err := os.Create(filepath.Join(os.TempDir(), "file"))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/reading-files/reading-files.go
+++ b/examples/reading-files/reading-files.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // Reading files requires checking most calls for errors.
@@ -21,16 +22,18 @@ func check(e error) {
 
 func main() {
 
+	path := filepath.Join(os.TempDir(), "dat")
+
 	// Perhaps the most basic file reading task is
 	// slurping a file's entire contents into memory.
-	dat, err := os.ReadFile("/tmp/dat")
+	dat, err := os.ReadFile(path)
 	check(err)
 	fmt.Print(string(dat))
 
 	// You'll often want more control over how and what
 	// parts of a file are read. For these tasks, start
 	// by `Open`ing a file to obtain an `os.File` value.
-	f, err := os.Open("/tmp/dat")
+	f, err := os.Open(path)
 	check(err)
 
 	// Read some bytes from the beginning of the file.

--- a/examples/writing-files/writing-files.go
+++ b/examples/writing-files/writing-files.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func check(e error) {
@@ -20,11 +21,11 @@ func main() {
 	// To start, here's how to dump a string (or just
 	// bytes) into a file.
 	d1 := []byte("hello\ngo\n")
-	err := os.WriteFile("/tmp/dat1", d1, 0644)
+	err := os.WriteFile(filepath.Join(os.TempDir(), "dat1"), d1, 0644)
 	check(err)
 
 	// For more granular writes, open a file for writing.
-	f, err := os.Create("/tmp/dat2")
+	f, err := os.Create(filepath.Join(os.TempDir(), "dat2"))
 	check(err)
 
 	// It's idiomatic to defer a `Close` immediately


### PR DESCRIPTION
Replaced all instances of hardcoded "/tmp/..." paths with `filepath.Join(os.TempDir(), ...)` to ensure compatibility on Windows systems. This aligns with Go's cross-platform best practices and addresses issue #562.

Also added clarifying comments in examples where code was unreachable due to panic.