### PR TITLE
Ignore arrow key press if the Command key is held on MacOS

### DIFF
--- a/public/arrays
+++ b/public/arrays
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/atomic-counters
+++ b/public/atomic-counters
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/base64-encoding
+++ b/public/base64-encoding
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/channel-buffering
+++ b/public/channel-buffering
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/channel-directions
+++ b/public/channel-directions
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/channel-synchronization
+++ b/public/channel-synchronization
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/channels
+++ b/public/channels
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/closing-channels
+++ b/public/closing-channels
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/closures
+++ b/public/closures
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/command-line-arguments
+++ b/public/command-line-arguments
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/command-line-flags
+++ b/public/command-line-flags
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/command-line-subcommands
+++ b/public/command-line-subcommands
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/constants
+++ b/public/constants
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/context
+++ b/public/context
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/custom-errors
+++ b/public/custom-errors
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/defer
+++ b/public/defer
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/directories
+++ b/public/directories
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/embed-directive
+++ b/public/embed-directive
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/enums
+++ b/public/enums
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/environment-variables
+++ b/public/environment-variables
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/epoch
+++ b/public/epoch
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/errors
+++ b/public/errors
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/execing-processes
+++ b/public/execing-processes
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/exit
+++ b/public/exit
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/file-paths
+++ b/public/file-paths
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/for
+++ b/public/for
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/functions
+++ b/public/functions
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/generics
+++ b/public/generics
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/goroutines
+++ b/public/goroutines
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/hello-world
+++ b/public/hello-world
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/http-client
+++ b/public/http-client
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/http-server
+++ b/public/http-server
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/if-else
+++ b/public/if-else
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/interfaces
+++ b/public/interfaces
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/json
+++ b/public/json
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/line-filters
+++ b/public/line-filters
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/logging
+++ b/public/logging
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/maps
+++ b/public/maps
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/methods
+++ b/public/methods
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/multiple-return-values
+++ b/public/multiple-return-values
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/mutexes
+++ b/public/mutexes
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/non-blocking-channel-operations
+++ b/public/non-blocking-channel-operations
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/number-parsing
+++ b/public/number-parsing
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/panic
+++ b/public/panic
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/pointers
+++ b/public/pointers
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/random-numbers
+++ b/public/random-numbers
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/range-over-built-in-types
+++ b/public/range-over-built-in-types
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/range-over-channels
+++ b/public/range-over-channels
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/range-over-iterators
+++ b/public/range-over-iterators
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/rate-limiting
+++ b/public/rate-limiting
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/reading-files
+++ b/public/reading-files
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/recover
+++ b/public/recover
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/recursion
+++ b/public/recursion
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/regular-expressions
+++ b/public/regular-expressions
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/select
+++ b/public/select
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/sha256-hashes
+++ b/public/sha256-hashes
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/signals
+++ b/public/signals
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/slices
+++ b/public/slices
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/sorting
+++ b/public/sorting
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/sorting-by-functions
+++ b/public/sorting-by-functions
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/spawning-processes
+++ b/public/spawning-processes
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/stateful-goroutines
+++ b/public/stateful-goroutines
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/string-formatting
+++ b/public/string-formatting
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/string-functions
+++ b/public/string-functions
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/strings-and-runes
+++ b/public/strings-and-runes
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/struct-embedding
+++ b/public/struct-embedding
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/structs
+++ b/public/structs
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/switch
+++ b/public/switch
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/temporary-files-and-directories
+++ b/public/temporary-files-and-directories
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/testing-and-benchmarking
+++ b/public/testing-and-benchmarking
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/text-templates
+++ b/public/text-templates
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/tickers
+++ b/public/tickers
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/time
+++ b/public/time
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/time-formatting-parsing
+++ b/public/time-formatting-parsing
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/timeouts
+++ b/public/timeouts
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/timers
+++ b/public/timers
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/url-parsing
+++ b/public/url-parsing
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/values
+++ b/public/values
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/variables
+++ b/public/variables
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/variadic-functions
+++ b/public/variadic-functions
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/waitgroups
+++ b/public/waitgroups
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/worker-pools
+++ b/public/worker-pools
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/writing-files
+++ b/public/writing-files
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/public/xml
+++ b/public/xml
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           

--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -7,7 +7,7 @@
   </head>
   <script>
       window.onkeydown = (e) => {
-          if (e.ctrlKey || e.altKey || e.shiftKey) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
               return;
           }
           {{if .PrevExample}}


### PR DESCRIPTION
This PR includes the `metaKey` (the "Command" key on Mac) in the modifier keys check when handling the keydown event. This fixes a bug for navigating when using MacOS. Specifically, the MacOS shortcut for navigating history in the browser is `cmd+left/right`, however currently this leads to unexpected behaviour where it sometimes navigates according to the browser history, and other times according the site's internal navigation logic.

With these changes, the command key press on MacOS is now handled as expected.
   