### PR TITLE
(minor): update mutexes example to use wg.Go instead of manual creation

### DIFF
--- a/examples/mutexes/mutexes.go
+++ b/examples/mutexes/mutexes.go
@@ -45,16 +45,22 @@ func main() {
 		for range n {
 			c.inc(name)
 		}
-		wg.Done()
 	}
 
 	// Run several goroutines concurrently; note
 	// that they all access the same `Container`,
 	// and two of them access the same counter.
-	wg.Add(3)
-	go doIncrement("a", 10000)
-	go doIncrement("a", 10000)
-	go doIncrement("b", 10000)
+	wg.Go(func() {
+		doIncrement("a", 10000)
+	})
+
+	wg.Go(func() {
+		doIncrement("a", 10000)
+	})
+
+	wg.Go(func() {
+		doIncrement("b", 10000)
+	})
 
 	// Wait for the goroutines to finish
 	wg.Wait()


### PR DESCRIPTION
This PR contains an update proposal to use wg.Go function in the mutexes section, as showed in an example of WaitGroups section. This function was introduces in go 1.25 https://pkg.go.dev/sync#WaitGroup.Go