### PR TITLE
fix issues : Error executing code due to file path on windows #562

### DIFF
--- a/examples/defer/defer.go
+++ b/examples/defer/defer.go
@@ -20,7 +20,7 @@ func main() {
 	// with `closeFile`. This will be executed at the end
 	// of the enclosing function (`main`), after
 	// `writeFile` has finished.
-	f := createFile("/tmp/defer.txt")
+	f := createFile(filepath.Join(os.TempDir(), "defer.txt"))
 	defer closeFile(f)
 	writeFile(f)
 }


### PR DESCRIPTION
 f := createFile("/tmp/defer.txt")  : This code does not work in Windows.
Corrected universal code:
f := createFile(filepath.Join(os.TempDir(), "defer.txt"))