### PR TITLE
Add import for filepath package

### DIFF
--- a/examples/defer/defer.go
+++ b/examples/defer/defer.go
@@ -4,7 +4,7 @@
 // `ensure` and `finally` would be used in other languages.
 
 package main
-
+import "path/filepath"
 import (
 	"fmt"
 	"os"


### PR DESCRIPTION
Fixed error. If you’re hitting a compile error in a branch or a different example, add the missing import:
  import "path/filepath"