### PR TITLE
feat(example.tmpl): Add previous navigation to example pages

### DIFF
--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -25,6 +25,11 @@
   <body>
     <div class="example" id="{{.ID}}">
       <h2><a href="./">Go by Example</a>: {{.Name}}</h2>
+    {{if .PrevExample}}
+      <p class="prev">
+        Previous example: <a href="{{.PrevExample.ID}}" rel="prev">{{.PrevExample.Name}}</a>.
+      </p>
+      {{end}}
       {{range .Segs}}
       <table>
         {{range .}}
@@ -40,6 +45,7 @@
         {{end}}
       </table>
       {{end}}
+  
       {{if .NextExample}}
       <p class="next">
         Next example: <a href="{{.NextExample.ID}}" rel="next">{{.NextExample.Name}}</a>.

--- a/templates/site.css
+++ b/templates/site.css
@@ -75,6 +75,10 @@ div.example table {
 p.next {
   margin-bottom: 20px;
 }
+p.prev {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
 p.footer {
   font-size: 75%;
 }


### PR DESCRIPTION
**Add previous navigation to example pages**

Add an explicit "Previous example" link/button to the example template so
each example page shows a backwards navigation link in addition to the
existing keyboard navigation. The link uses rel="prev" for semantics.

Files changed:
- templates/example.tmpl
- templates/site.css

Note: I was using this website and needed a button to go back, so I added it now. 
<img width="1360" height="948" alt="image" src="https://github.com/user-attachments/assets/31358b72-c2dd-48aa-b10d-0db142f84db8" />


