### PR TITLE
open Go playground in a new tab

### DIFF
--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -33,7 +33,7 @@
             {{.DocsRendered}}
           </td>
           <td class="code{{if .CodeEmpty}} empty{{end}}{{if .CodeLeading}} leading{{end}}">
-            {{if .CodeRun}}<a href="https://go.dev/play/p/{{$.URLHash}}"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />{{end}}
+            {{if .CodeRun}}<a href="https://go.dev/play/p/{{$.URLHash}}" target="_blank"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />{{end}}
           {{.CodeRendered}}
           </td>
         </tr>


### PR DESCRIPTION
In examples the Go playground link opens in a new tab, so user stays on the website