### PR TITLE
Improved mobile responsiveness of homepage section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>Go by Example</title>
     <link rel=stylesheet href="site.css">
   </head>

--- a/public/site.css
+++ b/public/site.css
@@ -227,3 +227,15 @@ body .c1 { color: #808080 }  /* Comment.Single */
   body .go { color: #868686 }  /* Generic.Output */
   body .c1 { color: #868686 }  /* Comment.Single */
 }
+
+/* Mobile improvements */
+@media (max-width: 768px) {
+  div#intro {
+    width: 100%;
+    min-width: unset;
+    max-width: 100%;
+    padding-left: 16px;
+    padding-right: 16px;
+    box-sizing: border-box;
+  }
+}

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" name="viewport" content="width=device-width, initial-scale=1">
     <title>Go by Example</title>
     <link rel=stylesheet href="site.css">
   </head>

--- a/templates/site.css
+++ b/templates/site.css
@@ -227,3 +227,15 @@ body .c1 { color: #808080 }  /* Comment.Single */
   body .go { color: #868686 }  /* Generic.Output */
   body .c1 { color: #868686 }  /* Comment.Single */
 }
+
+/* Mobile improvements */
+@media (max-width: 768px) {
+  div#intro {
+    width: 100%;
+    min-width: unset;
+    max-width: 100%;
+    padding-left: 16px;
+    padding-right: 16px;
+    box-sizing: border-box;
+  }
+}


### PR DESCRIPTION
This PR improves the mobile responsiveness of the homepage intro section.

Changes Made:
- Added responsive override for screens below 768px
- Removed fixed minimum width constraint on mobile
- Ensured full-width layout adapts properly to smaller screens
- Adjusted padding to improve readability and tap experience
- Prevented unintended horizontal scrolling

Result:

- Layout now fits properly within the mobile viewport
- No horizontal scroll
- Improved readability and clicking/touch experience
- Desktop layout remains unchanged

Before/after screenshots are attached for comparison.

**Before:**

<img src="https://github.com/user-attachments/assets/ed8e87a6-2480-44fa-864a-67ca993c9005" width="350">

**After:**

<img src="https://github.com/user-attachments/assets/302d9513-0e9c-4331-9402-b277457ee7c8" width="350">

Please let me know if any refinements or adjustments are needed. Happy to update accordingly.
Related to #649 