### PR TITLE
Improve example listing readability in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,602 +33,432 @@
 
       <p style="font-size:14px; color:#888; margin-bottom:12px;">85 examples</p>
       <ul style="list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fill, minmax(220px, 1fr)); gap:4px;">
-      
-        <li>
-          <a href="hello-world" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Hello World
-          </a>
-        </li>
-      
-        <li>
-          <a href="values" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Values
-          </a>
-        </li>
-      
-        <li>
-          <a href="variables" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Variables
-          </a>
-        </li>
-      
-        <li>
-          <a href="constants" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Constants
-          </a>
-        </li>
-      
-        <li>
-          <a href="for" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            For
-          </a>
-        </li>
-      
-        <li>
-          <a href="if-else" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            If/Else
-          </a>
-        </li>
-      
-        <li>
-          <a href="switch" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Switch
-          </a>
-        </li>
-      
-        <li>
-          <a href="arrays" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Arrays
-          </a>
-        </li>
-      
-        <li>
-          <a href="slices" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Slices
-          </a>
-        </li>
-      
-        <li>
-          <a href="maps" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Maps
-          </a>
-        </li>
-      
-        <li>
-          <a href="functions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Functions
-          </a>
-        </li>
-      
-        <li>
-          <a href="multiple-return-values" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Multiple Return Values
-          </a>
-        </li>
-      
-        <li>
-          <a href="variadic-functions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Variadic Functions
-          </a>
-        </li>
-      
-        <li>
-          <a href="closures" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Closures
-          </a>
-        </li>
-      
-        <li>
-          <a href="recursion" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Recursion
-          </a>
-        </li>
-      
-        <li>
-          <a href="range-over-built-in-types" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Range over Built-in Types
-          </a>
-        </li>
-      
-        <li>
-          <a href="pointers" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Pointers
-          </a>
-        </li>
-      
-        <li>
-          <a href="strings-and-runes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Strings and Runes
-          </a>
-        </li>
-      
-        <li>
-          <a href="structs" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Structs
-          </a>
-        </li>
-      
-        <li>
-          <a href="methods" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Methods
-          </a>
-        </li>
-      
-        <li>
-          <a href="interfaces" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Interfaces
-          </a>
-        </li>
-      
-        <li>
-          <a href="enums" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Enums
-          </a>
-        </li>
-      
-        <li>
-          <a href="struct-embedding" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Struct Embedding
-          </a>
-        </li>
-      
-        <li>
-          <a href="generics" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Generics
-          </a>
-        </li>
-      
-        <li>
-          <a href="range-over-iterators" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Range over Iterators
-          </a>
-        </li>
-      
-        <li>
-          <a href="errors" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Errors
-          </a>
-        </li>
-      
-        <li>
-          <a href="custom-errors" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Custom Errors
-          </a>
-        </li>
-      
-        <li>
-          <a href="goroutines" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Goroutines
-          </a>
-        </li>
-      
-        <li>
-          <a href="channels" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Channels
-          </a>
-        </li>
-      
-        <li>
-          <a href="channel-buffering" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Channel Buffering
-          </a>
-        </li>
-      
-        <li>
-          <a href="channel-synchronization" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Channel Synchronization
-          </a>
-        </li>
-      
-        <li>
-          <a href="channel-directions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Channel Directions
-          </a>
-        </li>
-      
-        <li>
-          <a href="select" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Select
-          </a>
-        </li>
-      
-        <li>
-          <a href="timeouts" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Timeouts
-          </a>
-        </li>
-      
-        <li>
-          <a href="non-blocking-channel-operations" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Non-Blocking Channel Operations
-          </a>
-        </li>
-      
-        <li>
-          <a href="closing-channels" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Closing Channels
-          </a>
-        </li>
-      
-        <li>
-          <a href="range-over-channels" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Range over Channels
-          </a>
-        </li>
-      
-        <li>
-          <a href="timers" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Timers
-          </a>
-        </li>
-      
-        <li>
-          <a href="tickers" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Tickers
-          </a>
-        </li>
-      
-        <li>
-          <a href="worker-pools" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Worker Pools
-          </a>
-        </li>
-      
-        <li>
-          <a href="waitgroups" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            WaitGroups
-          </a>
-        </li>
-      
-        <li>
-          <a href="rate-limiting" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Rate Limiting
-          </a>
-        </li>
-      
-        <li>
-          <a href="atomic-counters" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Atomic Counters
-          </a>
-        </li>
-      
-        <li>
-          <a href="mutexes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Mutexes
-          </a>
-        </li>
-      
-        <li>
-          <a href="stateful-goroutines" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Stateful Goroutines
-          </a>
-        </li>
-      
-        <li>
-          <a href="sorting" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Sorting
-          </a>
-        </li>
-      
-        <li>
-          <a href="sorting-by-functions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Sorting by Functions
-          </a>
-        </li>
-      
-        <li>
-          <a href="panic" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Panic
-          </a>
-        </li>
-      
-        <li>
-          <a href="defer" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Defer
-          </a>
-        </li>
-      
-        <li>
-          <a href="recover" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Recover
-          </a>
-        </li>
-      
-        <li>
-          <a href="string-functions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            String Functions
-          </a>
-        </li>
-      
-        <li>
-          <a href="string-formatting" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            String Formatting
-          </a>
-        </li>
-      
-        <li>
-          <a href="text-templates" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Text Templates
-          </a>
-        </li>
-      
-        <li>
-          <a href="regular-expressions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Regular Expressions
-          </a>
-        </li>
-      
-        <li>
-          <a href="json" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            JSON
-          </a>
-        </li>
-      
-        <li>
-          <a href="xml" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            XML
-          </a>
-        </li>
-      
-        <li>
-          <a href="time" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Time
-          </a>
-        </li>
-      
-        <li>
-          <a href="epoch" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Epoch
-          </a>
-        </li>
-      
-        <li>
-          <a href="time-formatting-parsing" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Time Formatting / Parsing
-          </a>
-        </li>
-      
-        <li>
-          <a href="random-numbers" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Random Numbers
-          </a>
-        </li>
-      
-        <li>
-          <a href="number-parsing" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Number Parsing
-          </a>
-        </li>
-      
-        <li>
-          <a href="url-parsing" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            URL Parsing
-          </a>
-        </li>
-      
-        <li>
-          <a href="sha256-hashes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            SHA256 Hashes
-          </a>
-        </li>
-      
-        <li>
-          <a href="base64-encoding" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Base64 Encoding
-          </a>
-        </li>
-      
-        <li>
-          <a href="reading-files" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Reading Files
-          </a>
-        </li>
-      
-        <li>
-          <a href="writing-files" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Writing Files
-          </a>
-        </li>
-      
-        <li>
-          <a href="line-filters" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Line Filters
-          </a>
-        </li>
-      
-        <li>
-          <a href="file-paths" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            File Paths
-          </a>
-        </li>
-      
-        <li>
-          <a href="directories" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Directories
-          </a>
-        </li>
-      
-        <li>
-          <a href="temporary-files-and-directories" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Temporary Files and Directories
-          </a>
-        </li>
-      
-        <li>
-          <a href="embed-directive" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Embed Directive
-          </a>
-        </li>
-      
-        <li>
-          <a href="testing-and-benchmarking" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Testing and Benchmarking
-          </a>
-        </li>
-      
-        <li>
-          <a href="command-line-arguments" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Command-Line Arguments
-          </a>
-        </li>
-      
-        <li>
-          <a href="command-line-flags" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Command-Line Flags
-          </a>
-        </li>
-      
-        <li>
-          <a href="command-line-subcommands" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Command-Line Subcommands
-          </a>
-        </li>
-      
-        <li>
-          <a href="environment-variables" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Environment Variables
-          </a>
-        </li>
-      
-        <li>
-          <a href="logging" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Logging
-          </a>
-        </li>
-      
-        <li>
-          <a href="http-client" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            HTTP Client
-          </a>
-        </li>
-      
-        <li>
-          <a href="http-server" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            HTTP Server
-          </a>
-        </li>
-      
-        <li>
-          <a href="tcp-server" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            TCP Server
-          </a>
-        </li>
-      
-        <li>
-          <a href="context" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Context
-          </a>
-        </li>
-      
-        <li>
-          <a href="spawning-processes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Spawning Processes
-          </a>
-        </li>
-      
-        <li>
-          <a href="execing-processes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Exec'ing Processes
-          </a>
-        </li>
-      
-        <li>
-          <a href="signals" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Signals
-          </a>
-        </li>
-      
-        <li>
-          <a href="exit" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
-            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            Exit
-          </a>
-        </li>
-      
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="hello-world" style="text-decoration:none; color:inherit;">Hello World</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="values" style="text-decoration:none; color:inherit;">Values</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="variables" style="text-decoration:none; color:inherit;">Variables</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="constants" style="text-decoration:none; color:inherit;">Constants</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="for" style="text-decoration:none; color:inherit;">For</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="if-else" style="text-decoration:none; color:inherit;">If/Else</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="switch" style="text-decoration:none; color:inherit;">Switch</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="arrays" style="text-decoration:none; color:inherit;">Arrays</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="slices" style="text-decoration:none; color:inherit;">Slices</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="maps" style="text-decoration:none; color:inherit;">Maps</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="functions" style="text-decoration:none; color:inherit;">Functions</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="multiple-return-values" style="text-decoration:none; color:inherit;">Multiple Return Values</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="variadic-functions" style="text-decoration:none; color:inherit;">Variadic Functions</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="closures" style="text-decoration:none; color:inherit;">Closures</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="recursion" style="text-decoration:none; color:inherit;">Recursion</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="range-over-built-in-types" style="text-decoration:none; color:inherit;">Range over Built-in Types</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="pointers" style="text-decoration:none; color:inherit;">Pointers</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="strings-and-runes" style="text-decoration:none; color:inherit;">Strings and Runes</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="structs" style="text-decoration:none; color:inherit;">Structs</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="methods" style="text-decoration:none; color:inherit;">Methods</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="interfaces" style="text-decoration:none; color:inherit;">Interfaces</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="enums" style="text-decoration:none; color:inherit;">Enums</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="struct-embedding" style="text-decoration:none; color:inherit;">Struct Embedding</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="generics" style="text-decoration:none; color:inherit;">Generics</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="range-over-iterators" style="text-decoration:none; color:inherit;">Range over Iterators</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="errors" style="text-decoration:none; color:inherit;">Errors</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="custom-errors" style="text-decoration:none; color:inherit;">Custom Errors</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="goroutines" style="text-decoration:none; color:inherit;">Goroutines</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="channels" style="text-decoration:none; color:inherit;">Channels</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="channel-buffering" style="text-decoration:none; color:inherit;">Channel Buffering</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="channel-synchronization" style="text-decoration:none; color:inherit;">Channel Synchronization</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="channel-directions" style="text-decoration:none; color:inherit;">Channel Directions</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="select" style="text-decoration:none; color:inherit;">Select</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="timeouts" style="text-decoration:none; color:inherit;">Timeouts</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="non-blocking-channel-operations" style="text-decoration:none; color:inherit;">Non-Blocking Channel Operations</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="closing-channels" style="text-decoration:none; color:inherit;">Closing Channels</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="range-over-channels" style="text-decoration:none; color:inherit;">Range over Channels</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="timers" style="text-decoration:none; color:inherit;">Timers</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="tickers" style="text-decoration:none; color:inherit;">Tickers</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="worker-pools" style="text-decoration:none; color:inherit;">Worker Pools</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="waitgroups" style="text-decoration:none; color:inherit;">WaitGroups</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="rate-limiting" style="text-decoration:none; color:inherit;">Rate Limiting</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="atomic-counters" style="text-decoration:none; color:inherit;">Atomic Counters</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="mutexes" style="text-decoration:none; color:inherit;">Mutexes</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="stateful-goroutines" style="text-decoration:none; color:inherit;">Stateful Goroutines</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="sorting" style="text-decoration:none; color:inherit;">Sorting</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="sorting-by-functions" style="text-decoration:none; color:inherit;">Sorting by Functions</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="panic" style="text-decoration:none; color:inherit;">Panic</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="defer" style="text-decoration:none; color:inherit;">Defer</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="recover" style="text-decoration:none; color:inherit;">Recover</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="string-functions" style="text-decoration:none; color:inherit;">String Functions</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="string-formatting" style="text-decoration:none; color:inherit;">String Formatting</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="text-templates" style="text-decoration:none; color:inherit;">Text Templates</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="regular-expressions" style="text-decoration:none; color:inherit;">Regular Expressions</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="json" style="text-decoration:none; color:inherit;">JSON</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="xml" style="text-decoration:none; color:inherit;">XML</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="time" style="text-decoration:none; color:inherit;">Time</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="epoch" style="text-decoration:none; color:inherit;">Epoch</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="time-formatting-parsing" style="text-decoration:none; color:inherit;">Time Formatting / Parsing</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="random-numbers" style="text-decoration:none; color:inherit;">Random Numbers</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="number-parsing" style="text-decoration:none; color:inherit;">Number Parsing</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="url-parsing" style="text-decoration:none; color:inherit;">URL Parsing</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="sha256-hashes" style="text-decoration:none; color:inherit;">SHA256 Hashes</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="base64-encoding" style="text-decoration:none; color:inherit;">Base64 Encoding</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="reading-files" style="text-decoration:none; color:inherit;">Reading Files</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="writing-files" style="text-decoration:none; color:inherit;">Writing Files</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="line-filters" style="text-decoration:none; color:inherit;">Line Filters</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="file-paths" style="text-decoration:none; color:inherit;">File Paths</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="directories" style="text-decoration:none; color:inherit;">Directories</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="temporary-files-and-directories" style="text-decoration:none; color:inherit;">Temporary Files and Directories</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="embed-directive" style="text-decoration:none; color:inherit;">Embed Directive</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="testing-and-benchmarking" style="text-decoration:none; color:inherit;">Testing and Benchmarking</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="command-line-arguments" style="text-decoration:none; color:inherit;">Command-Line Arguments</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="command-line-flags" style="text-decoration:none; color:inherit;">Command-Line Flags</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="command-line-subcommands" style="text-decoration:none; color:inherit;">Command-Line Subcommands</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="environment-variables" style="text-decoration:none; color:inherit;">Environment Variables</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="logging" style="text-decoration:none; color:inherit;">Logging</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="http-client" style="text-decoration:none; color:inherit;">HTTP Client</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="http-server" style="text-decoration:none; color:inherit;">HTTP Server</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="tcp-server" style="text-decoration:none; color:inherit;">TCP Server</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="context" style="text-decoration:none; color:inherit;">Context</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="spawning-processes" style="text-decoration:none; color:inherit;">Spawning Processes</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="execing-processes" style="text-decoration:none; color:inherit;">Exec'ing Processes</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="signals" style="text-decoration:none; color:inherit;">Signals</a>
+          </li>
+        
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            <a href="exit" style="text-decoration:none; color:inherit;">Exit</a>
+          </li>
+        
       </ul>
 
     <p class="footer">

--- a/public/index.html
+++ b/public/index.html
@@ -31,177 +31,603 @@
         version if something isn't working.
       </p>
 
-      <ul>
-      
-        <li><a href="hello-world">Hello World</a></li>
-      
-        <li><a href="values">Values</a></li>
-      
-        <li><a href="variables">Variables</a></li>
-      
-        <li><a href="constants">Constants</a></li>
-      
-        <li><a href="for">For</a></li>
-      
-        <li><a href="if-else">If/Else</a></li>
-      
-        <li><a href="switch">Switch</a></li>
-      
-        <li><a href="arrays">Arrays</a></li>
-      
-        <li><a href="slices">Slices</a></li>
-      
-        <li><a href="maps">Maps</a></li>
-      
-        <li><a href="functions">Functions</a></li>
-      
-        <li><a href="multiple-return-values">Multiple Return Values</a></li>
-      
-        <li><a href="variadic-functions">Variadic Functions</a></li>
-      
-        <li><a href="closures">Closures</a></li>
-      
-        <li><a href="recursion">Recursion</a></li>
-      
-        <li><a href="range-over-built-in-types">Range over Built-in Types</a></li>
-      
-        <li><a href="pointers">Pointers</a></li>
-      
-        <li><a href="strings-and-runes">Strings and Runes</a></li>
-      
-        <li><a href="structs">Structs</a></li>
-      
-        <li><a href="methods">Methods</a></li>
-      
-        <li><a href="interfaces">Interfaces</a></li>
-      
-        <li><a href="enums">Enums</a></li>
-      
-        <li><a href="struct-embedding">Struct Embedding</a></li>
-      
-        <li><a href="generics">Generics</a></li>
-      
-        <li><a href="range-over-iterators">Range over Iterators</a></li>
-      
-        <li><a href="errors">Errors</a></li>
-      
-        <li><a href="custom-errors">Custom Errors</a></li>
-      
-        <li><a href="goroutines">Goroutines</a></li>
-      
-        <li><a href="channels">Channels</a></li>
-      
-        <li><a href="channel-buffering">Channel Buffering</a></li>
-      
-        <li><a href="channel-synchronization">Channel Synchronization</a></li>
-      
-        <li><a href="channel-directions">Channel Directions</a></li>
-      
-        <li><a href="select">Select</a></li>
-      
-        <li><a href="timeouts">Timeouts</a></li>
-      
-        <li><a href="non-blocking-channel-operations">Non-Blocking Channel Operations</a></li>
-      
-        <li><a href="closing-channels">Closing Channels</a></li>
-      
-        <li><a href="range-over-channels">Range over Channels</a></li>
-      
-        <li><a href="timers">Timers</a></li>
-      
-        <li><a href="tickers">Tickers</a></li>
-      
-        <li><a href="worker-pools">Worker Pools</a></li>
-      
-        <li><a href="waitgroups">WaitGroups</a></li>
-      
-        <li><a href="rate-limiting">Rate Limiting</a></li>
-      
-        <li><a href="atomic-counters">Atomic Counters</a></li>
-      
-        <li><a href="mutexes">Mutexes</a></li>
-      
-        <li><a href="stateful-goroutines">Stateful Goroutines</a></li>
-      
-        <li><a href="sorting">Sorting</a></li>
-      
-        <li><a href="sorting-by-functions">Sorting by Functions</a></li>
-      
-        <li><a href="panic">Panic</a></li>
-      
-        <li><a href="defer">Defer</a></li>
-      
-        <li><a href="recover">Recover</a></li>
-      
-        <li><a href="string-functions">String Functions</a></li>
-      
-        <li><a href="string-formatting">String Formatting</a></li>
-      
-        <li><a href="text-templates">Text Templates</a></li>
-      
-        <li><a href="regular-expressions">Regular Expressions</a></li>
-      
-        <li><a href="json">JSON</a></li>
-      
-        <li><a href="xml">XML</a></li>
-      
-        <li><a href="time">Time</a></li>
-      
-        <li><a href="epoch">Epoch</a></li>
-      
-        <li><a href="time-formatting-parsing">Time Formatting / Parsing</a></li>
-      
-        <li><a href="random-numbers">Random Numbers</a></li>
-      
-        <li><a href="number-parsing">Number Parsing</a></li>
-      
-        <li><a href="url-parsing">URL Parsing</a></li>
-      
-        <li><a href="sha256-hashes">SHA256 Hashes</a></li>
-      
-        <li><a href="base64-encoding">Base64 Encoding</a></li>
-      
-        <li><a href="reading-files">Reading Files</a></li>
-      
-        <li><a href="writing-files">Writing Files</a></li>
-      
-        <li><a href="line-filters">Line Filters</a></li>
-      
-        <li><a href="file-paths">File Paths</a></li>
-      
-        <li><a href="directories">Directories</a></li>
-      
-        <li><a href="temporary-files-and-directories">Temporary Files and Directories</a></li>
-      
-        <li><a href="embed-directive">Embed Directive</a></li>
-      
-        <li><a href="testing-and-benchmarking">Testing and Benchmarking</a></li>
-      
-        <li><a href="command-line-arguments">Command-Line Arguments</a></li>
-      
-        <li><a href="command-line-flags">Command-Line Flags</a></li>
-      
-        <li><a href="command-line-subcommands">Command-Line Subcommands</a></li>
-      
-        <li><a href="environment-variables">Environment Variables</a></li>
-      
-        <li><a href="logging">Logging</a></li>
-      
-        <li><a href="http-client">HTTP Client</a></li>
-      
-        <li><a href="http-server">HTTP Server</a></li>
-      
-        <li><a href="tcp-server">TCP Server</a></li>
-      
-        <li><a href="context">Context</a></li>
-      
-        <li><a href="spawning-processes">Spawning Processes</a></li>
-      
-        <li><a href="execing-processes">Exec'ing Processes</a></li>
-      
-        <li><a href="signals">Signals</a></li>
-      
-        <li><a href="exit">Exit</a></li>
+      <p style="font-size:14px; color:#888; margin-bottom:12px;">85 examples</p>
+      <ul style="list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fill, minmax(220px, 1fr)); gap:4px;">
+      
+        <li>
+          <a href="hello-world" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Hello World
+          </a>
+        </li>
+      
+        <li>
+          <a href="values" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Values
+          </a>
+        </li>
+      
+        <li>
+          <a href="variables" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Variables
+          </a>
+        </li>
+      
+        <li>
+          <a href="constants" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Constants
+          </a>
+        </li>
+      
+        <li>
+          <a href="for" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            For
+          </a>
+        </li>
+      
+        <li>
+          <a href="if-else" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            If/Else
+          </a>
+        </li>
+      
+        <li>
+          <a href="switch" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Switch
+          </a>
+        </li>
+      
+        <li>
+          <a href="arrays" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Arrays
+          </a>
+        </li>
+      
+        <li>
+          <a href="slices" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Slices
+          </a>
+        </li>
+      
+        <li>
+          <a href="maps" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Maps
+          </a>
+        </li>
+      
+        <li>
+          <a href="functions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Functions
+          </a>
+        </li>
+      
+        <li>
+          <a href="multiple-return-values" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Multiple Return Values
+          </a>
+        </li>
+      
+        <li>
+          <a href="variadic-functions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Variadic Functions
+          </a>
+        </li>
+      
+        <li>
+          <a href="closures" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Closures
+          </a>
+        </li>
+      
+        <li>
+          <a href="recursion" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Recursion
+          </a>
+        </li>
+      
+        <li>
+          <a href="range-over-built-in-types" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Range over Built-in Types
+          </a>
+        </li>
+      
+        <li>
+          <a href="pointers" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Pointers
+          </a>
+        </li>
+      
+        <li>
+          <a href="strings-and-runes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Strings and Runes
+          </a>
+        </li>
+      
+        <li>
+          <a href="structs" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Structs
+          </a>
+        </li>
+      
+        <li>
+          <a href="methods" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Methods
+          </a>
+        </li>
+      
+        <li>
+          <a href="interfaces" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Interfaces
+          </a>
+        </li>
+      
+        <li>
+          <a href="enums" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Enums
+          </a>
+        </li>
+      
+        <li>
+          <a href="struct-embedding" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Struct Embedding
+          </a>
+        </li>
+      
+        <li>
+          <a href="generics" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Generics
+          </a>
+        </li>
+      
+        <li>
+          <a href="range-over-iterators" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Range over Iterators
+          </a>
+        </li>
+      
+        <li>
+          <a href="errors" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Errors
+          </a>
+        </li>
+      
+        <li>
+          <a href="custom-errors" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Custom Errors
+          </a>
+        </li>
+      
+        <li>
+          <a href="goroutines" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Goroutines
+          </a>
+        </li>
+      
+        <li>
+          <a href="channels" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Channels
+          </a>
+        </li>
+      
+        <li>
+          <a href="channel-buffering" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Channel Buffering
+          </a>
+        </li>
+      
+        <li>
+          <a href="channel-synchronization" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Channel Synchronization
+          </a>
+        </li>
+      
+        <li>
+          <a href="channel-directions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Channel Directions
+          </a>
+        </li>
+      
+        <li>
+          <a href="select" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Select
+          </a>
+        </li>
+      
+        <li>
+          <a href="timeouts" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Timeouts
+          </a>
+        </li>
+      
+        <li>
+          <a href="non-blocking-channel-operations" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Non-Blocking Channel Operations
+          </a>
+        </li>
+      
+        <li>
+          <a href="closing-channels" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Closing Channels
+          </a>
+        </li>
+      
+        <li>
+          <a href="range-over-channels" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Range over Channels
+          </a>
+        </li>
+      
+        <li>
+          <a href="timers" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Timers
+          </a>
+        </li>
+      
+        <li>
+          <a href="tickers" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Tickers
+          </a>
+        </li>
+      
+        <li>
+          <a href="worker-pools" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Worker Pools
+          </a>
+        </li>
+      
+        <li>
+          <a href="waitgroups" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            WaitGroups
+          </a>
+        </li>
+      
+        <li>
+          <a href="rate-limiting" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Rate Limiting
+          </a>
+        </li>
+      
+        <li>
+          <a href="atomic-counters" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Atomic Counters
+          </a>
+        </li>
+      
+        <li>
+          <a href="mutexes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Mutexes
+          </a>
+        </li>
+      
+        <li>
+          <a href="stateful-goroutines" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Stateful Goroutines
+          </a>
+        </li>
+      
+        <li>
+          <a href="sorting" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Sorting
+          </a>
+        </li>
+      
+        <li>
+          <a href="sorting-by-functions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Sorting by Functions
+          </a>
+        </li>
+      
+        <li>
+          <a href="panic" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Panic
+          </a>
+        </li>
+      
+        <li>
+          <a href="defer" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Defer
+          </a>
+        </li>
+      
+        <li>
+          <a href="recover" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Recover
+          </a>
+        </li>
+      
+        <li>
+          <a href="string-functions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            String Functions
+          </a>
+        </li>
+      
+        <li>
+          <a href="string-formatting" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            String Formatting
+          </a>
+        </li>
+      
+        <li>
+          <a href="text-templates" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Text Templates
+          </a>
+        </li>
+      
+        <li>
+          <a href="regular-expressions" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Regular Expressions
+          </a>
+        </li>
+      
+        <li>
+          <a href="json" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            JSON
+          </a>
+        </li>
+      
+        <li>
+          <a href="xml" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            XML
+          </a>
+        </li>
+      
+        <li>
+          <a href="time" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Time
+          </a>
+        </li>
+      
+        <li>
+          <a href="epoch" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Epoch
+          </a>
+        </li>
+      
+        <li>
+          <a href="time-formatting-parsing" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Time Formatting / Parsing
+          </a>
+        </li>
+      
+        <li>
+          <a href="random-numbers" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Random Numbers
+          </a>
+        </li>
+      
+        <li>
+          <a href="number-parsing" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Number Parsing
+          </a>
+        </li>
+      
+        <li>
+          <a href="url-parsing" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            URL Parsing
+          </a>
+        </li>
+      
+        <li>
+          <a href="sha256-hashes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            SHA256 Hashes
+          </a>
+        </li>
+      
+        <li>
+          <a href="base64-encoding" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Base64 Encoding
+          </a>
+        </li>
+      
+        <li>
+          <a href="reading-files" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Reading Files
+          </a>
+        </li>
+      
+        <li>
+          <a href="writing-files" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Writing Files
+          </a>
+        </li>
+      
+        <li>
+          <a href="line-filters" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Line Filters
+          </a>
+        </li>
+      
+        <li>
+          <a href="file-paths" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            File Paths
+          </a>
+        </li>
+      
+        <li>
+          <a href="directories" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Directories
+          </a>
+        </li>
+      
+        <li>
+          <a href="temporary-files-and-directories" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Temporary Files and Directories
+          </a>
+        </li>
+      
+        <li>
+          <a href="embed-directive" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Embed Directive
+          </a>
+        </li>
+      
+        <li>
+          <a href="testing-and-benchmarking" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Testing and Benchmarking
+          </a>
+        </li>
+      
+        <li>
+          <a href="command-line-arguments" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Command-Line Arguments
+          </a>
+        </li>
+      
+        <li>
+          <a href="command-line-flags" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Command-Line Flags
+          </a>
+        </li>
+      
+        <li>
+          <a href="command-line-subcommands" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Command-Line Subcommands
+          </a>
+        </li>
+      
+        <li>
+          <a href="environment-variables" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Environment Variables
+          </a>
+        </li>
+      
+        <li>
+          <a href="logging" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Logging
+          </a>
+        </li>
+      
+        <li>
+          <a href="http-client" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            HTTP Client
+          </a>
+        </li>
+      
+        <li>
+          <a href="http-server" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            HTTP Server
+          </a>
+        </li>
+      
+        <li>
+          <a href="tcp-server" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            TCP Server
+          </a>
+        </li>
+      
+        <li>
+          <a href="context" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Context
+          </a>
+        </li>
+      
+        <li>
+          <a href="spawning-processes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Spawning Processes
+          </a>
+        </li>
+      
+        <li>
+          <a href="execing-processes" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Exec'ing Processes
+          </a>
+        </li>
+      
+        <li>
+          <a href="signals" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Signals
+          </a>
+        </li>
+      
+        <li>
+          <a href="exit" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            Exit
+          </a>
+        </li>
       
       </ul>
 

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -33,14 +33,12 @@
 
       <p style="font-size:14px; color:#888; margin-bottom:12px;">{{len .}} examples</p>
       <ul style="list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fill, minmax(220px, 1fr)); gap:4px;">
-      {{range .}}
-        <li>
-          <a href="{{.ID}}" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+        {{range .}}
+          <li style="display:flex; align-items:center; gap:10px; padding:8px 12px;">
             <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
-            {{.Name}}
-          </a>
-        </li>
-      {{end}}
+            <a href="{{.ID}}" style="text-decoration:none; color:inherit;">{{.Name}}</a>
+          </li>
+        {{end}}
       </ul>
 {{ template "footer" }}
     </div>

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -31,9 +31,15 @@
         version if something isn't working.
       </p>
 
-      <ul>
+      <p style="font-size:14px; color:#888; margin-bottom:12px;">{{len .}} examples</p>
+      <ul style="list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fill, minmax(220px, 1fr)); gap:4px;">
       {{range .}}
-        <li><a href="{{.ID}}">{{.Name}}</a></li>
+        <li>
+          <a href="{{.ID}}" style="display:flex; align-items:center; gap:10px; padding:8px 12px; border-radius:6px; text-decoration:none; color:inherit;">
+            <span style="width:6px; height:6px; border-radius:50%; background:#1D9E75; flex-shrink:0; display:inline-block;"></span>
+            {{.Name}}
+          </a>
+        </li>
       {{end}}
       </ul>
 {{ template "footer" }}


### PR DESCRIPTION

While going through the site I noticed the example list on the index page feels a bit cramped, especially with 80+ examples stacked together. So I made a small change but this change makes the list easier to read without altering the site's overall structure or style.

### What is changed
Added spacing and visual breathing room to the example list on the index page.

### Here's how the updated site looks like:

<img width="696" height="1558" alt="go-by-example-improved" src="https://github.com/user-attachments/assets/8c4c23fb-b508-496a-87cc-16e280e41adc" />
