### PR TITLE
fix(examples): migrate signals example from syscall to golang.org/x/sys/unix

### DIFF
--- a/examples/signals/signals.go
+++ b/examples/signals/signals.go
@@ -11,14 +11,15 @@ import (
 	"context"
 	"fmt"
 	"os/signal"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func main() {
 	// `signal.NotifyContext` returns a context that's canceled
 	// when one of the listed signals arrives.
 	ctx, stop := signal.NotifyContext(
-		context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		context.Background(), unix.SIGINT, unix.SIGTERM)
 	defer stop()
 
 	// The program will wait here until one of the

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	github.com/alecthomas/chroma/v2 v2.10.0
+	golang.org/x/sys v0.38.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.19.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3


### PR DESCRIPTION
## Summary

Closes #656 - migrates the signals example away from the deprecated syscall package.

## Problem

The signals example uses syscall to reference signal constants (syscall.SIGINT, syscall.SIGTERM). The syscall package is frozen and its documentation recommends migrating to golang.org/x/sys.

## Changes

- examples/signals/signals.go: Replace syscall import with golang.org/x/sys/unix. Use unix.SIGINT and unix.SIGTERM instead of their syscall counterparts.
- go.mod: Add golang.org/x/sys v0.38.0 as a direct dependency.

## Verification

The unix.SIGINT and unix.SIGTERM constants have identical integer values to their syscall counterparts, so the program behavior is unchanged.