### PR TITLE
feat: improve text selection behavior in columns

### DIFF
--- a/public/site.css
+++ b/public/site.css
@@ -121,6 +121,12 @@ td.code {
 td.code.leading {
   padding-bottom: 11px;
 }
+body.selecting-code td.docs,
+body.selecting-docs td.code {
+  -webkit-user-select: none;
+  cursor: text;
+  user-select: none;
+}
 pre, code {
   font-size: 14px; line-height: 18px;
   font-family: 'Menlo', 'Monaco', 'Consolas', 'Lucida Console', monospace;

--- a/public/site.js
+++ b/public/site.js
@@ -15,3 +15,61 @@ var clipboard = new Clipboard('.copy', {
         return codeLines.filter(function(cL) { return cL != '' }).join("\n").replace(/\n$/, '');
     }
 });
+
+function clearSelectionSide() {
+    document.body.classList.remove('selecting-code', 'selecting-docs');
+}
+
+var pointerIsDown = false;
+
+function clearSelectionSideIfEmpty() {
+    var selection = window.getSelection();
+
+    if (!selection || selection.isCollapsed) {
+        clearSelectionSide();
+    }
+}
+
+function applySelectionSide(side) {
+    if (side == 'code') {
+        document.body.classList.add('selecting-code');
+    } else if (side == 'docs') {
+        document.body.classList.add('selecting-docs');
+    }
+}
+
+document.addEventListener('pointerdown', function(e) {
+    var selection = window.getSelection();
+    var selectionSide = '';
+
+    pointerIsDown = true;
+
+    if (e.target.closest('td.code')) {
+        selectionSide = 'code';
+    } else if (e.target.closest('td.docs')) {
+        selectionSide = 'docs';
+    }
+
+    if (selection && !selection.isCollapsed) {
+        selection.removeAllRanges();
+    }
+
+    clearSelectionSide();
+    applySelectionSide(selectionSide);
+});
+
+document.addEventListener('selectionchange', function(e) {
+    if (!pointerIsDown) {
+        clearSelectionSideIfEmpty();
+    }
+});
+
+document.addEventListener('pointerup', function(e) {
+    pointerIsDown = false;
+    clearSelectionSideIfEmpty();
+});
+
+document.addEventListener('pointercancel', function(e) {
+    pointerIsDown = false;
+    clearSelectionSide();
+});

--- a/templates/site.css
+++ b/templates/site.css
@@ -121,6 +121,12 @@ td.code {
 td.code.leading {
   padding-bottom: 11px;
 }
+body.selecting-code td.docs,
+body.selecting-docs td.code {
+  -webkit-user-select: none;
+  cursor: text;
+  user-select: none;
+}
 pre, code {
   font-size: 14px; line-height: 18px;
   font-family: 'Menlo', 'Monaco', 'Consolas', 'Lucida Console', monospace;

--- a/templates/site.js
+++ b/templates/site.js
@@ -15,3 +15,61 @@ var clipboard = new Clipboard('.copy', {
         return codeLines.filter(function(cL) { return cL != '' }).join("\n").replace(/\n$/, '');
     }
 });
+
+function clearSelectionSide() {
+    document.body.classList.remove('selecting-code', 'selecting-docs');
+}
+
+var pointerIsDown = false;
+
+function clearSelectionSideIfEmpty() {
+    var selection = window.getSelection();
+
+    if (!selection || selection.isCollapsed) {
+        clearSelectionSide();
+    }
+}
+
+function applySelectionSide(side) {
+    if (side == 'code') {
+        document.body.classList.add('selecting-code');
+    } else if (side == 'docs') {
+        document.body.classList.add('selecting-docs');
+    }
+}
+
+document.addEventListener('pointerdown', function(e) {
+    var selection = window.getSelection();
+    var selectionSide = '';
+
+    pointerIsDown = true;
+
+    if (e.target.closest('td.code')) {
+        selectionSide = 'code';
+    } else if (e.target.closest('td.docs')) {
+        selectionSide = 'docs';
+    }
+
+    if (selection && !selection.isCollapsed) {
+        selection.removeAllRanges();
+    }
+
+    clearSelectionSide();
+    applySelectionSide(selectionSide);
+});
+
+document.addEventListener('selectionchange', function(e) {
+    if (!pointerIsDown) {
+        clearSelectionSideIfEmpty();
+    }
+});
+
+document.addEventListener('pointerup', function(e) {
+    pointerIsDown = false;
+    clearSelectionSideIfEmpty();
+});
+
+document.addEventListener('pointercancel', function(e) {
+    pointerIsDown = false;
+    clearSelectionSide();
+});


### PR DESCRIPTION
This PR improves copy behavior in the document/code table view.

When content is selected in one column (document or code), text selection is temporarily disabled in the other column (`user-select: none`). This prevents cross-column selection interference and allows multi-row content to be copied correctly.

Related issues: 
- https://github.com/mmcgrana/gobyexample/issues/496
- https://github.com/mmcgrana/gobyexample/issues/590
- https://github.com/mmcgrana/gobyexample/issues/448

Preview at: 
https://htmlpreview.github.io/?https://github.com/ikkz/gobyexample/blob/fix/copy/public/arrays

<img width="873" height="588" alt="image" src="https://github.com/user-attachments/assets/b6675d0c-dbe9-44cd-8b82-a85b22de6a5b" />
<img width="911" height="483" alt="image" src="https://github.com/user-attachments/assets/6bf4c49f-c1b4-4f33-9fce-bf4bd42beb15" />
