### PR TITLE
docs: add uzbek translation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Contributor translations of the Go by Example site are available in:
 * [Ukrainian](https://butuzov.github.io/gobyexample/) by [butuzov](https://github.com/butuzov/gobyexample)
 * [Brazilian Portuguese](https://lcslitx.github.io/GoEmExemplos/) by [lcslitx](https://github.com/LCSLITX)
 * [Burmese](https://setkyar.github.io/gobyexample) by [Set Kyar Wa Lar](https://github.com/setkyar/gobyexample)
+* [Uzbek](https://elchintoyirov.github.io/gobyexample/) by [elchintoyirov](https://github.com/elchintoyirov/gobyexample)
 
 ### Thanks
 


### PR DESCRIPTION
adds a link to the uzbek (latin) translation of go by example.

site: https://elchintoyirov.github.io/gobyexample/
source: https://github.com/elchintoyirov/gobyexample