### PR TITLE
docs: add Arabic translation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Contributor translations of the Go by Example site are available in:
 * [Brazilian Portuguese](https://lcslitx.github.io/GoEmExemplos/) by [lcslitx](https://github.com/LCSLITX)
 * [Burmese](https://setkyar.github.io/gobyexample) by [Set Kyar Wa Lar](https://github.com/setkyar/gobyexample)
 * [Uzbek](https://elchintoyirov.github.io/gobyexample/) by [elchintoyirov](https://github.com/elchintoyirov/gobyexample)
+* [Arabic](https://0xKa.github.io/gobyexample-ar/) by [0xKa](https://github.com/0xKa/gobyexample-ar)
 
 ### Thanks
 


### PR DESCRIPTION
Adds the completed Arabic translation to the contributor translations list.

- Site: https://0xKa.github.io/gobyexample-ar/
- Source: https://github.com/0xKa/gobyexample-ar
- Includes all 85 examples with RTL support