### PR TITLE
add missing fmt.Println outputs in pointers example

### DIFF
--- a/examples/pointers/pointers.sh
+++ b/examples/pointers/pointers.sh
@@ -6,3 +6,5 @@ initial: 1
 zeroval: 1
 zeroptr: 0
 pointer: 0x42131100
+value at *p: 42
+value at *p: 0

--- a/public/pointers
+++ b/public/pointers
@@ -176,7 +176,9 @@ the memory address for that variable.</p>
 </span></span><span class="line"><span class="cl"><span class="go">initial: 1
 </span></span></span><span class="line"><span class="cl"><span class="go">zeroval: 1
 </span></span></span><span class="line"><span class="cl"><span class="go">zeroptr: 0
-</span></span></span><span class="line"><span class="cl"><span class="go">pointer: 0x42131100</span></span></span></code></pre>
+</span></span></span><span class="line"><span class="cl"><span class="go">pointer: 0x42131100
+</span></span></span><span class="line"><span class="cl"><span class="go">value at *p: 42
+</span></span></span><span class="line"><span class="cl"><span class="go">value at *p: 0</span></span></span></code></pre>
           </td>
         </tr>
         


### PR DESCRIPTION
Fixes #669 

<img width="1227" height="1040" alt="image" src="https://github.com/user-attachments/assets/b1401695-7eba-4433-a6d8-b2aa5db3793e" />
