### PR TITLE
Fix missing output lines in Pointers example

### DIFF
--- a/examples/pointers/pointers.sh
+++ b/examples/pointers/pointers.sh
@@ -6,3 +6,5 @@ initial: 1
 zeroval: 1
 zeroptr: 0
 pointer: 0x42131100
+value at *p: 42
+value at *p: 0

--- a/public/pointers
+++ b/public/pointers
@@ -176,7 +176,9 @@ the memory address for that variable.</p>
 </span></span><span class="line"><span class="cl"><span class="go">initial: 1
 </span></span></span><span class="line"><span class="cl"><span class="go">zeroval: 1
 </span></span></span><span class="line"><span class="cl"><span class="go">zeroptr: 0
-</span></span></span><span class="line"><span class="cl"><span class="go">pointer: 0x42131100</span></span></span></code></pre>
+</span></span></span><span class="line"><span class="cl"><span class="go">pointer: 0x42131100
+</span></span></span><span class="line"><span class="cl"><span class="go">value at *p: 42
+</span></span></span><span class="line"><span class="cl"><span class="go">value at *p: 0</span></span></span></code></pre>
           </td>
         </tr>
         


### PR DESCRIPTION
## Summary

The Pointers example's expected output (`examples/pointers/pointers.sh`) and generated HTML (`public/pointers`) were missing the last two output lines from the `new(42)` section of the example code.

The Go source (`examples/pointers/pointers.go`) has two additional `fmt.Println` calls at the end that produce:
```
value at *p: 42
value at *p: 0
```

These lines were absent from both the `.sh` file (which drives the displayed output on the website) and the pre-built `public/pointers` HTML. This PR adds the two missing lines to both files so the displayed output matches the actual program output.

## Changes

- `examples/pointers/pointers.sh`: Added `value at *p: 42` and `value at *p: 0` after the `pointer: 0x42131100` line.
- `public/pointers`: Updated the generated HTML to include the two missing output lines in the chroma-highlighted `<pre>` block.

Per `CONTRIBUTING.md`, both the source file and the generated HTML are updated together.

Addresses #669

---

**AI Usage Disclosure:** An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.