### PR TITLE
Added EXAMPLE_FILE_SUFIX and .FileNameSufix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ To build the site you'll need Go installed. Run:
 $ tools/build
 ```
 
+To build the HTML files for the site with a `.html` file name suffix. Run:
+
+```console
+$ export EXAMPLE_FILE_SUFIX=".html"
+$ tools/build
+```
+The environment variable `EXAMPLE_FILE_SUFIX` is used in `tools/generate.go`
+
 To build continuously in a loop:
 
 ```console

--- a/templates/example.tmpl
+++ b/templates/example.tmpl
@@ -12,12 +12,12 @@
           }
           {{if .PrevExample}}
           if (e.key == "ArrowLeft") {
-              window.location.href = '{{.PrevExample.ID}}';
+              window.location.href = '{{.PrevExample.ID}}{{.PrevExample.FileNameSufix}}';
           }
           {{end}}
           {{if .NextExample}}
           if (e.key == "ArrowRight") {
-              window.location.href = '{{.NextExample.ID}}';
+              window.location.href = '{{.NextExample.ID}}{{.NextExample.FileNameSufix}}';
           }
           {{end}}
       }
@@ -42,7 +42,7 @@
       {{end}}
       {{if .NextExample}}
       <p class="next">
-        Next example: <a href="{{.NextExample.ID}}" rel="next">{{.NextExample.Name}}</a>.
+        Next example: <a href="{{.NextExample.ID}}{{.NextExample.FileNameSufix}}" rel="next">{{.NextExample.Name}}</a>.
       </p>
       {{end}}
 {{ template "footer" }}

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -16,11 +16,11 @@
         <a href="https://go.dev/doc/tutorial/getting-started">official documentation</a>
         to learn more.
       </p>
-
+        {{$first:= index . 0}}
       <p>
         <em>Go by Example</em> is a hands-on introduction
         to Go using annotated example programs. Check out
-        the <a href="hello-world">first example</a> or
+        the <a href="{{$first.ID}}{{$first.FileNameSufix}}">first example</a> or
         browse the full list below.
       </p>
 
@@ -33,7 +33,7 @@
 
       <ul>
       {{range .}}
-        <li><a href="{{.ID}}">{{.Name}}</a></li>
+        <li><a href="{{.ID}}{{.FileNameSufix}}">{{.Name}}</a></li>
       {{end}}
       </ul>
 {{ template "footer" }}

--- a/tools/generate.go
+++ b/tools/generate.go
@@ -107,7 +107,7 @@ type Seg struct {
 
 // Example is info extracted from an example file
 type Example struct {
-	ID, Name                    string
+	ID, Name, FileNameSufix     string
 	GoCode, GoCodeHash, URLHash string
 	Segs                        [][]*Seg
 	PrevExample                 *Example
@@ -249,11 +249,12 @@ func parseExamples() []*Example {
 		}
 	}
 	examples := make([]*Example, 0)
+
 	for i, exampleName := range exampleNames {
 		if verbose() {
 			fmt.Printf("Processing %s [%d/%d]\n", exampleName, i+1, len(exampleNames))
 		}
-		example := Example{Name: exampleName}
+		example := Example{Name: exampleName, FileNameSufix: os.Getenv("EXAMPLE_FILE_SUFIX")}
 		exampleID := strings.ToLower(exampleName)
 		exampleID = strings.Replace(exampleID, " ", "-", -1)
 		exampleID = strings.Replace(exampleID, "/", "-", -1)
@@ -313,7 +314,7 @@ func renderExamples(examples []*Example) {
 	template.Must(exampleTmpl.Parse(mustReadFile("templates/footer.tmpl")))
 	template.Must(exampleTmpl.Parse(mustReadFile("templates/example.tmpl")))
 	for _, example := range examples {
-		exampleF, err := os.Create(siteDir + "/" + example.ID)
+		exampleF, err := os.Create(siteDir + "/" + example.ID + example.FileNameSufix)
 		check(err)
 		defer exampleF.Close()
 		check(exampleTmpl.Execute(exampleF, example))


### PR DESCRIPTION
I have a cheap shared hosting account served by Apache.
I want to upload my generated files from the public folder to an arbitrary folder under my domain name.

I do not want to add specific for this folder .htaccess file to serve the produced static files without file extensions in the arbitrary folder.
I want Apache or any other server to simply serve the *.html files.