### PR TITLE
Fix invalid new(42) syntax in pointers example and rebuild

### DIFF
--- a/examples/pointers/pointers.go
+++ b/examples/pointers/pointers.go
@@ -42,7 +42,8 @@ func main() {
 
 	// A new pointer to a value can be created with the
 	// builtin function `new`.
-	p := new(42)
+	p := new(int)
+	*p = 42
 	fmt.Println("value at *p:", *p)
 	zeroptr(p)
 	fmt.Println("value at *p:", *p)

--- a/examples/pointers/pointers.hash
+++ b/examples/pointers/pointers.hash
@@ -1,2 +1,2 @@
-71d3d52b2febb2ba9da7ba9cb8cfa469f4a4462d
-B928SrV-F9M
+90bf32563c78ebb6c3e4f3bff1fd2924d5afd10e
+Sing9e-Ni9S

--- a/public/pointers
+++ b/public/pointers
@@ -46,7 +46,7 @@ within your program.</p>
             
           </td>
           <td class="code leading">
-            <a href="https://go.dev/play/p/B928SrV-F9M"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
+            <a href="https://go.dev/play/p/Sing9e-Ni9S"><img title="Run code" src="play.png" class="run" /></a><img title="Copy code" src="clipboard.png" class="copy" />
           <pre class="chroma"><code><span class="line"><span class="cl"><span class="kn">package</span> <span class="nx">main</span></span></span></code></pre>
           </td>
         </tr>
@@ -151,7 +151,8 @@ builtin function <code>new</code>.</p>
           </td>
           <td class="code">
             
-          <pre class="chroma"><code><span class="line"><span class="cl">    <span class="nx">p</span> <span class="o">:=</span> <span class="nb">new</span><span class="p">(</span><span class="mi">42</span><span class="p">)</span>
+          <pre class="chroma"><code><span class="line"><span class="cl">    <span class="nx">p</span> <span class="o">:=</span> <span class="nb">new</span><span class="p">(</span><span class="kt">int</span><span class="p">)</span>
+</span></span><span class="line"><span class="cl">    <span class="o">*</span><span class="nx">p</span> <span class="p">=</span> <span class="mi">42</span>
 </span></span><span class="line"><span class="cl">    <span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;value at *p:&#34;</span><span class="p">,</span> <span class="o">*</span><span class="nx">p</span><span class="p">)</span>
 </span></span><span class="line"><span class="cl">    <span class="nf">zeroptr</span><span class="p">(</span><span class="nx">p</span><span class="p">)</span>
 </span></span><span class="line"><span class="cl">    <span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;value at *p:&#34;</span><span class="p">,</span> <span class="o">*</span><span class="nx">p</span><span class="p">)</span>
@@ -197,7 +198,7 @@ the memory address for that variable.</p>
     </div>
     <script>
       var codeLines = [];
-      codeLines.push('');codeLines.push('package main\u000A');codeLines.push('import \"fmt\"\u000A');codeLines.push('func zeroval(ival int) {\u000A    ival \u003D 0\u000A}\u000A');codeLines.push('func zeroptr(iptr *int) {\u000A    *iptr \u003D 0\u000A}\u000A');codeLines.push('func main() {\u000A    i :\u003D 1\u000A    fmt.Println(\"initial:\", i)\u000A');codeLines.push('    zeroval(i)\u000A    fmt.Println(\"zeroval:\", i)\u000A');codeLines.push('    zeroptr(\u0026i)\u000A    fmt.Println(\"zeroptr:\", i)\u000A');codeLines.push('    fmt.Println(\"pointer:\", \u0026i)\u000A');codeLines.push('    p :\u003D new(42)\u000A    fmt.Println(\"value at *p:\", *p)\u000A    zeroptr(p)\u000A    fmt.Println(\"value at *p:\", *p)\u000A}\u000A');codeLines.push('');
+      codeLines.push('');codeLines.push('package main\u000A');codeLines.push('import \"fmt\"\u000A');codeLines.push('func zeroval(ival int) {\u000A    ival \u003D 0\u000A}\u000A');codeLines.push('func zeroptr(iptr *int) {\u000A    *iptr \u003D 0\u000A}\u000A');codeLines.push('func main() {\u000A    i :\u003D 1\u000A    fmt.Println(\"initial:\", i)\u000A');codeLines.push('    zeroval(i)\u000A    fmt.Println(\"zeroval:\", i)\u000A');codeLines.push('    zeroptr(\u0026i)\u000A    fmt.Println(\"zeroptr:\", i)\u000A');codeLines.push('    fmt.Println(\"pointer:\", \u0026i)\u000A');codeLines.push('    p :\u003D new(int)\u000A    *p \u003D 42\u000A    fmt.Println(\"value at *p:\", *p)\u000A    zeroptr(p)\u000A    fmt.Println(\"value at *p:\", *p)\u000A}\u000A');codeLines.push('');
     </script>
     <script src="site.js" async></script>
   </body>


### PR DESCRIPTION
Fixes a syntax error where `new(42)` was used instead of allocating an int type (`new(int)`). 

Regenerated the site using `tools/build`.